### PR TITLE
chore: use --load with docker buildx

### DIFF
--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-DOCKER_BUILDKIT=1 docker buildx build --platform=linux/amd64 -f Dockerfile \
+DOCKER_BUILDKIT=1 docker buildx build --load --platform=linux/amd64 -f Dockerfile \
   --build-arg PIP_VERSION="$PIP_VERSION" \
   --build-arg PIPELINE_PACKAGE="$PIPELINE_PACKAGE" \
   --progress plain \


### PR DESCRIPTION
Use --load which is necessary with buildx sometimes to be
able to run the image. E.g., in github CI.

Consistency with https://github.com/Unstructured-IO/pipeline-template/pull/10
