### PR TITLE
chore: bump core dependencies and remove old rate limiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Updated Dockerfile for public release
 * Remove rate limiting in the API
 * Add file type validation via UNSTRUCTURED_ALLOWED_MIMETYPES
+* Major semver route also supported: /general/v0/general 
 
 ## 0.0.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.0.5
+
+* Updated Dockerfile for public release
+* Remove rate limiting in the API
+* Add file type validation via UNSTRUCTURED_ALLOWED_MIMETYPES
+
 ## 0.0.4
 
 * Changed pipeline name to `pipeline-general`

--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ check-tests:
 ## tidy:                        run black
 .PHONY: tidy
 tidy:
-	black --line-length 100 ${PACKAGE_NAME}
+	black --line-length 100 ${PACKAGE_NAME} --exclude ${PACKAGE_NAME}/api
 	black --line-length 100 test_${PIPELINE_PACKAGE}
 
 ## check-scripts:               run shellcheck

--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,6 @@ check-version:
 # Fail if syncing version would produce changes
 	scripts/version-sync.sh -c \
 		-s CHANGELOG.md \
-		-f README.md api-release \
 		-f preprocessing-pipeline-family.yaml release
 
 ## check-notebooks:             check that executing and cleaning notebooks doesn't produce changes

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Give a description of making API calls using example `curl` commands, and exampl
 For example:
 ```
  curl -X 'POST' \
-  'http://localhost:8000/general/v0.0.4/general' \
+  'http://localhost:8000/general/v0.0.5/general' \
   -H 'accept: application/json' \
   -H 'Content-Type: multipart/form-data' \
   -F 'files=@family-day.eml' \

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Give a description of making API calls using example `curl` commands, and exampl
 For example:
 ```
  curl -X 'POST' \
-  'http://localhost:8000/general/v0.0.5/general' \
+  'http://localhost:8000/general/v0/general' \
   -H 'accept: application/json' \
   -H 'Content-Type: multipart/form-data' \
   -F 'files=@family-day.eml' \

--- a/exploration-notebooks/exploration-email.ipynb
+++ b/exploration-notebooks/exploration-email.ipynb
@@ -422,14 +422,14 @@
     {
      "data": {
       "text/plain": [
-       "[<unstructured.documents.html.HTMLText>,\n",
+       "[<unstructured.documents.html.HTMLTitle>,\n",
        " <unstructured.documents.html.HTMLNarrativeText>,\n",
        " <unstructured.documents.html.HTMLNarrativeText>,\n",
        " <unstructured.documents.html.HTMLListItem>,\n",
        " <unstructured.documents.html.HTMLListItem>,\n",
        " <unstructured.documents.html.HTMLListItem>,\n",
        " <unstructured.documents.html.HTMLText>,\n",
-       " <unstructured.documents.html.HTMLText>]"
+       " <unstructured.documents.html.HTMLTitle>]"
       ]
      },
      "execution_count": null,

--- a/prepline_general/api/app.py
+++ b/prepline_general/api/app.py
@@ -6,21 +6,14 @@
 
 from fastapi import FastAPI, Request, status
 
-from slowapi import Limiter, _rate_limit_exceeded_handler
-from slowapi.errors import RateLimitExceeded
-from slowapi.util import get_remote_address
-
 from .general import router as general_router
 
 
-limiter = Limiter(key_func=get_remote_address)
 app = FastAPI(
     title="Unstructured Pipeline API",
     description="""""",
     version="1.0.0",
 )
-app.state.limiter = limiter
-app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 
 app.include_router(general_router)
 

--- a/prepline_general/api/app.py
+++ b/prepline_general/api/app.py
@@ -13,6 +13,7 @@ app = FastAPI(
     title="Unstructured Pipeline API",
     description="""""",
     version="1.0.0",
+    docs_url="/general/docs",
 )
 
 app.include_router(general_router)

--- a/prepline_general/api/general.py
+++ b/prepline_general/api/general.py
@@ -236,6 +236,19 @@ async def pipeline_1(
         )
 
 
+@router.post("/general/v0/general")
+async def short_pipeline_1(
+    request: Request,
+    files: Union[List[UploadFile], None] = File(default=None),
+    output_format: Union[str, None] = Form(default=None),
+):
+    return await pipeline_1(
+        request=request,
+        files=files,
+        output_format=output_format,
+    )
+
+
 @app.get("/healthcheck", status_code=status.HTTP_200_OK)
 async def healthcheck(request: Request):
     return {"healthcheck": "HEALTHCHECK STATUS: EVERYTHING OK!"}

--- a/prepline_general/api/general.py
+++ b/prepline_general/api/general.py
@@ -4,8 +4,18 @@
 #####################################################################
 
 import os
+import mimetypes
 from typing import List, Union
-from fastapi import status, FastAPI, File, Form, Request, UploadFile, APIRouter
+from fastapi import (
+    status,
+    FastAPI,
+    File,
+    Form,
+    Request,
+    UploadFile,
+    APIRouter,
+    HTTPException,
+)
 from fastapi.responses import PlainTextResponse
 import json
 from fastapi.responses import StreamingResponse
@@ -53,6 +63,32 @@ def pipeline_api(file, filename="", response_type="application/json"):
         element["metadata"]["filename"] = os.path.basename(filename)
 
     return result
+
+
+def get_validated_mimetype(file):
+    """
+    Return a file's mimetype, either via the file.content_type or the mimetypes lib if that's too
+    generic. If the user has set UNSTRUCTURED_ALLOWED_MIMETYPES, validate against this list and
+    return HTTP 400 for an invalid type.
+    """
+    content_type = file.content_type
+    if content_type == "application/octet-stream":
+        content_type = mimetypes.guess_type(str(file.filename))[0]
+
+        # Markdown mimetype is too new for the library - just hardcode that one in for now
+        if not content_type and ".md" in file.filename:
+            content_type = "text/markdown"
+
+    allowed_mimetypes_str = os.environ.get("UNSTRUCTURED_ALLOWED_MIMETYPES")
+    if allowed_mimetypes_str is not None:
+        allowed_mimetypes = allowed_mimetypes_str.split(",")
+
+        if content_type not in allowed_mimetypes:
+            raise HTTPException(
+                status_code=400, detail=f"File type not supported: {file.filename}"
+            )
+
+    return content_type
 
 
 class MultipartMixedResponse(StreamingResponse):
@@ -144,6 +180,8 @@ async def pipeline_1(
 
             def response_generator(is_multipart):
                 for file in files:
+                    _ = get_validated_mimetype(file)
+
                     _file = file.file
 
                     response = pipeline_api(
@@ -165,6 +203,8 @@ async def pipeline_1(
         else:
             file = files[0]
             _file = file.file
+
+            _ = get_validated_mimetype(file)
 
             response = pipeline_api(
                 _file,

--- a/prepline_general/api/general.py
+++ b/prepline_general/api/general.py
@@ -6,9 +6,6 @@
 import os
 from typing import List, Union
 from fastapi import status, FastAPI, File, Form, Request, UploadFile, APIRouter
-from slowapi.errors import RateLimitExceeded
-from slowapi import Limiter, _rate_limit_exceeded_handler
-from slowapi.util import get_remote_address
 from fastapi.responses import PlainTextResponse
 import json
 from fastapi.responses import StreamingResponse
@@ -21,13 +18,8 @@ from unstructured.staging.base import convert_to_isd
 import tempfile
 
 
-limiter = Limiter(key_func=get_remote_address)
 app = FastAPI()
-app.state.limiter = limiter
-app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 router = APIRouter()
-
-RATE_LIMIT = os.environ.get("PIPELINE_API_RATE_LIMIT", "1/second")
 
 
 def is_expected_response_type(media_type, response_type):
@@ -122,7 +114,6 @@ class MultipartMixedResponse(StreamingResponse):
 
 
 @router.post("/general/v0.0.4/general")
-@limiter.limit(RATE_LIMIT)
 async def pipeline_1(
     request: Request,
     files: Union[List[UploadFile], None] = File(default=None),

--- a/prepline_general/api/general.py
+++ b/prepline_general/api/general.py
@@ -149,7 +149,7 @@ class MultipartMixedResponse(StreamingResponse):
         await send({"type": "http.response.body", "body": b"", "more_body": False})
 
 
-@router.post("/general/v0.0.4/general")
+@router.post("/general/v0.0.5/general")
 async def pipeline_1(
     request: Request,
     files: Union[List[UploadFile], None] = File(default=None),

--- a/preprocessing-pipeline-family.yaml
+++ b/preprocessing-pipeline-family.yaml
@@ -1,2 +1,2 @@
 name: general
-version: 0.0.4
+version: 0.0.5

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,5 +1,5 @@
-unstructured[local-inference]>=0.5.0
-unstructured-api-tools>=0.4.8
+unstructured[local-inference]>=0.5.4
+unstructured-api-tools>=0.5.0
 ratelimit
 requests
 

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,5 +1,5 @@
-unstructured[local-inference]>=0.5.4
-unstructured-api-tools>=0.5.0
+unstructured[local-inference]>=0.5.6
+unstructured-api-tools>=0.6.0
 ratelimit
 requests
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,7 +11,7 @@ anyio==3.6.2
     #   httpcore
     #   starlette
     #   watchfiles
-argilla==1.3.1
+argilla==1.4.0
     # via unstructured
 attrs==22.2.0
     # via jsonschema
@@ -29,7 +29,7 @@ certifi==2022.12.7
     #   unstructured
 cffi==1.15.1
     # via cryptography
-charset-normalizer==3.0.1
+charset-normalizer==3.1.0
     # via
     #   pdfminer-six
     #   requests
@@ -40,35 +40,36 @@ click==8.1.3
     #   uvicorn
 coloredlogs==15.0.1
     # via onnxruntime
+commonmark==0.9.1
+    # via rich
 contourpy==1.0.7
     # via matplotlib
-cryptography==39.0.1
+cryptography==39.0.2
     # via pdfminer-six
 cycler==0.11.0
     # via matplotlib
 defusedxml==0.7.1
     # via nbconvert
 deprecated==1.2.13
-    # via
-    #   argilla
-    #   limits
+    # via argilla
 effdet==0.3.0
     # via layoutparser
 et-xmlfile==1.1.0
     # via openpyxl
-fastapi==0.92.0
+fastapi==0.94.1
     # via
     #   unstructured-api-tools
     #   unstructured-inference
 fastjsonschema==2.16.3
     # via nbformat
-filelock==3.9.0
+filelock==3.10.0
     # via
     #   huggingface-hub
+    #   torch
     #   transformers
-flatbuffers==23.1.21
+flatbuffers==23.3.3
     # via onnxruntime
-fonttools==4.38.0
+fonttools==4.39.2
     # via matplotlib
 h11==0.14.0
     # via
@@ -80,7 +81,7 @@ httptools==0.5.0
     # via uvicorn
 httpx==0.23.3
     # via argilla
-huggingface-hub==0.12.1
+huggingface-hub==0.13.2
     # via
     #   timm
     #   transformers
@@ -106,16 +107,15 @@ iopath==0.1.10
 jinja2==3.1.2
     # via
     #   nbconvert
+    #   torch
     #   unstructured-api-tools
 joblib==1.2.0
     # via nltk
-jsons==1.6.3
-    # via unstructured-inference
 jsonschema==4.17.3
     # via nbformat
 jupyter-client==8.0.3
     # via nbclient
-jupyter-core==5.2.0
+jupyter-core==5.3.0
     # via
     #   jupyter-client
     #   nbclient
@@ -127,8 +127,6 @@ kiwisolver==1.4.4
     # via matplotlib
 layoutparser[layoutmodels,tesseract]==0.3.4
     # via unstructured-inference
-limits==2.8.0
-    # via slowapi
 lxml==4.9.2
     # via
     #   python-docx
@@ -140,26 +138,28 @@ markupsafe==2.1.2
     # via
     #   jinja2
     #   nbconvert
-matplotlib==3.7.0
+matplotlib==3.7.1
     # via pycocotools
 mistune==2.0.5
     # via nbconvert
 monotonic==1.6
     # via argilla
-mpmath==1.2.1
+mpmath==1.3.0
     # via sympy
-mypy==1.0.1
+mypy==1.1.1
     # via unstructured-api-tools
 mypy-extensions==1.0.0
     # via mypy
 nbclient==0.7.2
     # via nbconvert
-nbconvert==7.2.9
+nbconvert==7.2.10
     # via unstructured-api-tools
 nbformat==5.7.3
     # via
     #   nbclient
     #   nbconvert
+networkx==3.0
+    # via torch
 nltk==3.8.1
     # via unstructured
 numpy==1.23.5
@@ -183,13 +183,12 @@ opencv-python==4.6.0.66
     # via
     #   layoutparser
     #   unstructured-inference
-openpyxl==3.1.1
+openpyxl==3.1.2
     # via unstructured
-packaging==22.0
+packaging==23.0
     # via
     #   argilla
     #   huggingface-hub
-    #   limits
     #   matplotlib
     #   nbconvert
     #   onnxruntime
@@ -220,22 +219,26 @@ pillow==9.4.0
     #   unstructured
 pkgutil-resolve-name==1.3.10
     # via jsonschema
-platformdirs==3.0.0
+platformdirs==3.1.1
     # via jupyter-core
 portalocker==2.7.0
     # via iopath
-protobuf==4.22.0
+protobuf==4.22.1
     # via onnxruntime
 pycocotools==2.0.6
     # via effdet
 pycparser==2.21
     # via cffi
-pydantic==1.10.5
+pydantic==1.10.6
     # via
     #   argilla
     #   fastapi
 pygments==2.14.0
-    # via nbconvert
+    # via
+    #   nbconvert
+    #   rich
+pypandoc==1.11
+    # via unstructured
 pyparsing==3.0.9
     # via matplotlib
 pyrsistent==0.19.3
@@ -269,7 +272,7 @@ pyyaml==6.0
     #   timm
     #   transformers
     #   uvicorn
-pyzmq==25.0.0
+pyzmq==25.0.1
     # via jupyter-client
 ratelimit==2.2.1
     # via -r requirements/base.in
@@ -286,14 +289,14 @@ requests==2.28.2
     #   unstructured
 rfc3986[idna2008]==1.5.0
     # via httpx
+rich==13.0.1
+    # via argilla
 scipy==1.10.1
     # via layoutparser
 six==1.16.0
     # via
     #   bleach
     #   python-dateutil
-slowapi==0.1.7
-    # via unstructured-api-tools
 sniffio==1.3.0
     # via
     #   anyio
@@ -301,10 +304,12 @@ sniffio==1.3.0
     #   httpx
 soupsieve==2.4
     # via beautifulsoup4
-starlette==0.25.0
+starlette==0.26.1
     # via fastapi
 sympy==1.11.1
-    # via onnxruntime
+    # via
+    #   onnxruntime
+    #   torch
 timm==0.6.12
     # via effdet
 tinycss2==1.2.1
@@ -313,20 +318,20 @@ tokenizers==0.13.2
     # via transformers
 tomli==2.0.1
     # via mypy
-torch==1.13.1
+torch==2.0.0
     # via
     #   effdet
     #   layoutparser
     #   timm
     #   torchvision
-torchvision==0.14.1
+torchvision==0.15.1
     # via
     #   effdet
     #   layoutparser
     #   timm
 tornado==6.2
     # via jupyter-client
-tqdm==4.64.1
+tqdm==4.65.0
     # via
     #   argilla
     #   huggingface-hub
@@ -340,7 +345,7 @@ traitlets==5.9.0
     #   nbclient
     #   nbconvert
     #   nbformat
-transformers==4.26.1
+transformers==4.27.1
     # via unstructured-inference
 types-requests==2.28.11.15
     # via unstructured-api-tools
@@ -352,23 +357,20 @@ typing-extensions==4.5.0
     # via
     #   huggingface-hub
     #   iopath
-    #   limits
     #   mypy
     #   pydantic
+    #   rich
     #   starlette
     #   torch
-    #   torchvision
-typish==1.9.3
-    # via jsons
-unstructured[local-inference]==0.5.0
+unstructured[local-inference]==0.5.4
     # via -r requirements/base.in
-unstructured-api-tools==0.4.9
+unstructured-api-tools==0.5.0
     # via -r requirements/base.in
-unstructured-inference==0.2.7
+unstructured-inference==0.2.11
     # via unstructured
-urllib3==1.26.14
+urllib3==1.26.15
     # via requests
-uvicorn[standard]==0.20.0
+uvicorn[standard]==0.21.1
     # via
     #   unstructured-api-tools
     #   unstructured-inference
@@ -388,12 +390,9 @@ wrapt==1.14.1
     # via
     #   argilla
     #   deprecated
-xlsxwriter==3.0.8
+xlsxwriter==3.0.9
     # via python-pptx
 zipp==3.15.0
     # via
     #   importlib-metadata
     #   importlib-resources
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,13 +11,13 @@ anyio==3.6.2
     #   httpcore
     #   starlette
     #   watchfiles
-argilla==1.4.0
+argilla==1.5.0
     # via unstructured
 attrs==22.2.0
     # via jsonschema
 backoff==2.2.1
     # via argilla
-beautifulsoup4==4.11.2
+beautifulsoup4==4.12.0
     # via nbconvert
 bleach==6.0.0
     # via nbconvert
@@ -56,13 +56,13 @@ effdet==0.3.0
     # via layoutparser
 et-xmlfile==1.1.0
     # via openpyxl
-fastapi==0.94.1
+fastapi==0.95.0
     # via
     #   unstructured-api-tools
     #   unstructured-inference
 fastjsonschema==2.16.3
     # via nbformat
-filelock==3.10.0
+filelock==3.10.2
     # via
     #   huggingface-hub
     #   torch
@@ -81,7 +81,7 @@ httptools==0.5.0
     # via uvicorn
 httpx==0.23.3
     # via argilla
-huggingface-hub==0.13.2
+huggingface-hub==0.13.3
     # via
     #   timm
     #   transformers
@@ -93,7 +93,7 @@ idna==3.4
     #   anyio
     #   requests
     #   rfc3986
-importlib-metadata==6.0.0
+importlib-metadata==6.1.0
     # via
     #   jupyter-client
     #   markdown
@@ -113,7 +113,7 @@ joblib==1.2.0
     # via nltk
 jsonschema==4.17.3
     # via nbformat
-jupyter-client==8.0.3
+jupyter-client==8.1.0
     # via nbclient
 jupyter-core==5.3.0
     # via
@@ -132,7 +132,7 @@ lxml==4.9.2
     #   python-docx
     #   python-pptx
     #   unstructured
-markdown==3.4.1
+markdown==3.4.3
     # via unstructured
 markupsafe==2.1.2
     # via
@@ -154,7 +154,7 @@ nbclient==0.7.2
     # via nbconvert
 nbconvert==7.2.10
     # via unstructured-api-tools
-nbformat==5.7.3
+nbformat==5.8.0
     # via
     #   nbclient
     #   nbconvert
@@ -229,7 +229,7 @@ pycocotools==2.0.6
     # via effdet
 pycparser==2.21
     # via cffi
-pydantic==1.10.6
+pydantic==1.10.7
     # via
     #   argilla
     #   fastapi
@@ -272,11 +272,11 @@ pyyaml==6.0
     #   timm
     #   transformers
     #   uvicorn
-pyzmq==25.0.1
+pyzmq==25.0.2
     # via jupyter-client
 ratelimit==2.2.1
     # via -r requirements/base.in
-regex==2022.10.31
+regex==2023.3.22
     # via
     #   nltk
     #   transformers
@@ -345,9 +345,9 @@ traitlets==5.9.0
     #   nbclient
     #   nbconvert
     #   nbformat
-transformers==4.27.1
+transformers==4.27.2
     # via unstructured-inference
-types-requests==2.28.11.15
+types-requests==2.28.11.16
     # via unstructured-api-tools
 types-ujson==5.7.0.1
     # via unstructured-api-tools
@@ -362,9 +362,9 @@ typing-extensions==4.5.0
     #   rich
     #   starlette
     #   torch
-unstructured[local-inference]==0.5.4
+unstructured[local-inference]==0.5.6
     # via -r requirements/base.in
-unstructured-api-tools==0.5.0
+unstructured-api-tools==0.6.0
     # via -r requirements/base.in
 unstructured-inference==0.2.11
     # via unstructured

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -44,7 +44,7 @@ commonmark==0.9.1
     # via rich
 contourpy==1.0.7
     # via matplotlib
-cryptography==39.0.2
+cryptography==40.0.0
     # via pdfminer-six
 cycler==0.11.0
     # via matplotlib
@@ -62,7 +62,7 @@ fastapi==0.95.0
     #   unstructured-inference
 fastjsonschema==2.16.3
     # via nbformat
-filelock==3.10.2
+filelock==3.10.4
     # via
     #   huggingface-hub
     #   torch
@@ -276,7 +276,7 @@ pyzmq==25.0.2
     # via jupyter-client
 ratelimit==2.2.1
     # via -r requirements/base.in
-regex==2023.3.22
+regex==2023.3.23
     # via
     #   nltk
     #   transformers
@@ -310,7 +310,7 @@ sympy==1.11.1
     # via
     #   onnxruntime
     #   torch
-timm==0.6.12
+timm==0.6.13
     # via effdet
 tinycss2==1.2.1
     # via nbconvert
@@ -345,7 +345,7 @@ traitlets==5.9.0
     #   nbclient
     #   nbconvert
     #   nbformat
-transformers==4.27.2
+transformers==4.27.3
     # via unstructured-inference
 types-requests==2.28.11.16
     # via unstructured-api-tools
@@ -362,9 +362,9 @@ typing-extensions==4.5.0
     #   rich
     #   starlette
     #   torch
-unstructured[local-inference]==0.5.6
+unstructured[local-inference]==0.5.7
     # via -r requirements/base.in
-unstructured-api-tools==0.6.0
+unstructured-api-tools==0.8.0
     # via -r requirements/base.in
 unstructured-inference==0.2.11
     # via unstructured

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -100,7 +100,7 @@ contourpy==1.0.7
     #   matplotlib
 coverage[toml]==7.2.2
     # via pytest-cov
-cryptography==39.0.2
+cryptography==40.0.0
     # via
     #   -r requirements/base.txt
     #   pdfminer-six
@@ -148,7 +148,7 @@ fastjsonschema==2.16.3
     # via
     #   -r requirements/base.txt
     #   nbformat
-filelock==3.10.2
+filelock==3.10.4
     # via
     #   -r requirements/base.txt
     #   huggingface-hub
@@ -631,7 +631,7 @@ qtpy==2.3.0
     # via qtconsole
 ratelimit==2.2.1
     # via -r requirements/base.txt
-regex==2023.3.22
+regex==2023.3.23
     # via
     #   -r requirements/base.txt
     #   nltk
@@ -703,7 +703,7 @@ terminado==0.17.1
     #   jupyter-server-terminals
     #   nbclassic
     #   notebook
-timm==0.6.12
+timm==0.6.13
     # via
     #   -r requirements/base.txt
     #   effdet
@@ -771,7 +771,7 @@ traitlets==5.9.0
     #   nbformat
     #   notebook
     #   qtconsole
-transformers==4.27.2
+transformers==4.27.3
     # via
     #   -r requirements/base.txt
     #   unstructured-inference
@@ -798,9 +798,9 @@ typing-extensions==4.5.0
     #   rich
     #   starlette
     #   torch
-unstructured[local-inference]==0.5.6
+unstructured[local-inference]==0.5.7
     # via -r requirements/base.txt
-unstructured-api-tools==0.6.0
+unstructured-api-tools==0.8.0
     # via -r requirements/base.txt
 unstructured-inference==0.2.11
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -19,7 +19,7 @@ appnope==0.1.3
     # via
     #   ipykernel
     #   ipython
-argilla==1.4.0
+argilla==1.5.0
     # via
     #   -r requirements/base.txt
     #   unstructured
@@ -49,7 +49,7 @@ backoff==2.2.1
     # via
     #   -r requirements/base.txt
     #   argilla
-beautifulsoup4==4.11.2
+beautifulsoup4==4.12.0
     # via
     #   -r requirements/base.txt
     #   nbconvert
@@ -88,7 +88,7 @@ coloredlogs==15.0.1
     # via
     #   -r requirements/base.txt
     #   onnxruntime
-comm==0.1.2
+comm==0.1.3
     # via ipykernel
 commonmark==0.9.1
     # via
@@ -134,7 +134,7 @@ execnb==0.1.5
     # via nbdev
 executing==1.2.0
     # via stack-data
-fastapi==0.94.1
+fastapi==0.95.0
     # via
     #   -r requirements/base.txt
     #   unstructured-api-tools
@@ -148,7 +148,7 @@ fastjsonschema==2.16.3
     # via
     #   -r requirements/base.txt
     #   nbformat
-filelock==3.10.0
+filelock==3.10.2
     # via
     #   -r requirements/base.txt
     #   huggingface-hub
@@ -185,7 +185,7 @@ httpx==0.23.3
     # via
     #   -r requirements/base.txt
     #   argilla
-huggingface-hub==0.13.2
+huggingface-hub==0.13.3
     # via
     #   -r requirements/base.txt
     #   timm
@@ -202,7 +202,7 @@ idna==3.4
     #   jsonschema
     #   requests
     #   rfc3986
-importlib-metadata==6.0.0
+importlib-metadata==6.1.0
     # via
     #   -r requirements/base.txt
     #   jupyter-client
@@ -219,9 +219,8 @@ iopath==0.1.10
     # via
     #   -r requirements/base.txt
     #   layoutparser
-ipykernel==6.21.3
+ipykernel==6.22.0
     # via
-    #   ipywidgets
     #   jupyter
     #   jupyter-console
     #   nbclassic
@@ -238,7 +237,7 @@ ipython-genutils==0.2.0
     #   nbclassic
     #   notebook
     #   qtconsole
-ipywidgets==8.0.4
+ipywidgets==8.0.5
     # via jupyter
 isoduration==20.11.0
     # via jsonschema
@@ -266,7 +265,7 @@ jsonschema[format-nongpl]==4.17.3
     #   nbformat
 jupyter==1.0.0
     # via -r requirements/test.in
-jupyter-client==8.0.3
+jupyter-client==8.1.0
     # via
     #   -r requirements/base.txt
     #   ipykernel
@@ -303,7 +302,7 @@ jupyterlab-pygments==0.2.2
     # via
     #   -r requirements/base.txt
     #   nbconvert
-jupyterlab-widgets==3.0.5
+jupyterlab-widgets==3.0.6
     # via ipywidgets
 kiwisolver==1.4.4
     # via
@@ -319,7 +318,7 @@ lxml==4.9.2
     #   python-docx
     #   python-pptx
     #   unstructured
-markdown==3.4.1
+markdown==3.4.3
     # via
     #   -r requirements/base.txt
     #   unstructured
@@ -376,7 +375,7 @@ nbconvert==7.2.10
     #   unstructured-api-tools
 nbdev==2.3.12
     # via -r requirements/test.in
-nbformat==5.7.3
+nbformat==5.8.0
     # via
     #   -r requirements/base.txt
     #   jupyter-server
@@ -537,7 +536,7 @@ pycparser==2.21
     # via
     #   -r requirements/base.txt
     #   cffi
-pydantic==1.10.6
+pydantic==1.10.7
     # via
     #   -r requirements/base.txt
     #   argilla
@@ -616,7 +615,7 @@ pyyaml==6.0
     #   timm
     #   transformers
     #   uvicorn
-pyzmq==25.0.1
+pyzmq==25.0.2
     # via
     #   -r requirements/base.txt
     #   ipykernel
@@ -632,7 +631,7 @@ qtpy==2.3.0
     # via qtconsole
 ratelimit==2.2.1
     # via -r requirements/base.txt
-regex==2022.10.31
+regex==2023.3.22
     # via
     #   -r requirements/base.txt
     #   nltk
@@ -772,11 +771,11 @@ traitlets==5.9.0
     #   nbformat
     #   notebook
     #   qtconsole
-transformers==4.27.1
+transformers==4.27.2
     # via
     #   -r requirements/base.txt
     #   unstructured-inference
-types-requests==2.28.11.15
+types-requests==2.28.11.16
     # via
     #   -r requirements/base.txt
     #   unstructured-api-tools
@@ -799,9 +798,9 @@ typing-extensions==4.5.0
     #   rich
     #   starlette
     #   torch
-unstructured[local-inference]==0.5.4
+unstructured[local-inference]==0.5.6
     # via -r requirements/base.txt
-unstructured-api-tools==0.5.0
+unstructured-api-tools==0.6.0
     # via -r requirements/base.txt
 unstructured-inference==0.2.11
     # via
@@ -826,7 +825,7 @@ wand==0.6.11
     # via
     #   -r requirements/base.txt
     #   pdfplumber
-watchdog==2.3.1
+watchdog==3.0.0
     # via nbdev
 watchfiles==0.18.1
     # via
@@ -849,7 +848,7 @@ websockets==10.4
     #   uvicorn
 wheel==0.40.0
     # via astunparse
-widgetsnbextension==4.0.5
+widgetsnbextension==4.0.6
     # via ipywidgets
 wrapt==1.14.1
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -19,7 +19,7 @@ appnope==0.1.3
     # via
     #   ipykernel
     #   ipython
-argilla==1.3.1
+argilla==1.4.0
     # via
     #   -r requirements/base.txt
     #   unstructured
@@ -71,7 +71,7 @@ cffi==1.15.1
     #   -r requirements/base.txt
     #   argon2-cffi-bindings
     #   cryptography
-charset-normalizer==3.0.1
+charset-normalizer==3.1.0
     # via
     #   -r requirements/base.txt
     #   pdfminer-six
@@ -90,13 +90,17 @@ coloredlogs==15.0.1
     #   onnxruntime
 comm==0.1.2
     # via ipykernel
+commonmark==0.9.1
+    # via
+    #   -r requirements/base.txt
+    #   rich
 contourpy==1.0.7
     # via
     #   -r requirements/base.txt
     #   matplotlib
-coverage[toml]==7.2.1
+coverage[toml]==7.2.2
     # via pytest-cov
-cryptography==39.0.1
+cryptography==39.0.2
     # via
     #   -r requirements/base.txt
     #   pdfminer-six
@@ -116,7 +120,6 @@ deprecated==1.2.13
     # via
     #   -r requirements/base.txt
     #   argilla
-    #   limits
 effdet==0.3.0
     # via
     #   -r requirements/base.txt
@@ -125,13 +128,13 @@ et-xmlfile==1.1.0
     # via
     #   -r requirements/base.txt
     #   openpyxl
-exceptiongroup==1.1.0
+exceptiongroup==1.1.1
     # via pytest
 execnb==0.1.5
     # via nbdev
 executing==1.2.0
     # via stack-data
-fastapi==0.92.0
+fastapi==0.94.1
     # via
     #   -r requirements/base.txt
     #   unstructured-api-tools
@@ -145,18 +148,19 @@ fastjsonschema==2.16.3
     # via
     #   -r requirements/base.txt
     #   nbformat
-filelock==3.9.0
+filelock==3.10.0
     # via
     #   -r requirements/base.txt
     #   huggingface-hub
+    #   torch
     #   transformers
 flake8==6.0.0
     # via -r requirements/test.in
-flatbuffers==23.1.21
+flatbuffers==23.3.3
     # via
     #   -r requirements/base.txt
     #   onnxruntime
-fonttools==4.38.0
+fonttools==4.39.2
     # via
     #   -r requirements/base.txt
     #   matplotlib
@@ -181,7 +185,7 @@ httpx==0.23.3
     # via
     #   -r requirements/base.txt
     #   argilla
-huggingface-hub==0.12.1
+huggingface-hub==0.13.2
     # via
     #   -r requirements/base.txt
     #   timm
@@ -215,7 +219,7 @@ iopath==0.1.10
     # via
     #   -r requirements/base.txt
     #   layoutparser
-ipykernel==6.21.2
+ipykernel==6.21.3
     # via
     #   ipywidgets
     #   jupyter
@@ -247,6 +251,7 @@ jinja2==3.1.2
     #   nbclassic
     #   nbconvert
     #   notebook
+    #   torch
     #   unstructured-api-tools
 joblib==1.2.0
     # via
@@ -254,10 +259,6 @@ joblib==1.2.0
     #   nltk
 jsonpointer==2.3
     # via jsonschema
-jsons==1.6.3
-    # via
-    #   -r requirements/base.txt
-    #   unstructured-inference
 jsonschema[format-nongpl]==4.17.3
     # via
     #   -r requirements/base.txt
@@ -275,9 +276,9 @@ jupyter-client==8.0.3
     #   nbclient
     #   notebook
     #   qtconsole
-jupyter-console==6.6.2
+jupyter-console==6.6.3
     # via jupyter
-jupyter-core==5.2.0
+jupyter-core==5.3.0
     # via
     #   -r requirements/base.txt
     #   ipykernel
@@ -292,7 +293,7 @@ jupyter-core==5.2.0
     #   qtconsole
 jupyter-events==0.6.3
     # via jupyter-server
-jupyter-server==2.3.0
+jupyter-server==2.5.0
     # via
     #   nbclassic
     #   notebook-shim
@@ -312,10 +313,6 @@ layoutparser[layoutmodels,tesseract]==0.3.4
     # via
     #   -r requirements/base.txt
     #   unstructured-inference
-limits==2.8.0
-    # via
-    #   -r requirements/base.txt
-    #   slowapi
 lxml==4.9.2
     # via
     #   -r requirements/base.txt
@@ -331,7 +328,7 @@ markupsafe==2.1.2
     #   -r requirements/base.txt
     #   jinja2
     #   nbconvert
-matplotlib==3.7.0
+matplotlib==3.7.1
     # via
     #   -r requirements/base.txt
     #   pycocotools
@@ -349,11 +346,11 @@ monotonic==1.6
     # via
     #   -r requirements/base.txt
     #   argilla
-mpmath==1.2.1
+mpmath==1.3.0
     # via
     #   -r requirements/base.txt
     #   sympy
-mypy==1.0.1
+mypy==1.1.1
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.in
@@ -363,13 +360,13 @@ mypy-extensions==1.0.0
     #   -r requirements/base.txt
     #   black
     #   mypy
-nbclassic==0.5.2
+nbclassic==0.5.3
     # via notebook
 nbclient==0.7.2
     # via
     #   -r requirements/base.txt
     #   nbconvert
-nbconvert==7.2.9
+nbconvert==7.2.10
     # via
     #   -r requirements/base.txt
     #   jupyter
@@ -392,11 +389,15 @@ nest-asyncio==1.5.6
     #   ipykernel
     #   nbclassic
     #   notebook
+networkx==3.0
+    # via
+    #   -r requirements/base.txt
+    #   torch
 nltk==3.8.1
     # via
     #   -r requirements/base.txt
     #   unstructured
-notebook==6.5.2
+notebook==6.5.3
     # via jupyter
 notebook-shim==0.2.2
     # via nbclassic
@@ -427,11 +428,11 @@ opencv-python==4.6.0.66
     #   -r requirements/base.txt
     #   layoutparser
     #   unstructured-inference
-openpyxl==3.1.1
+openpyxl==3.1.2
     # via
     #   -r requirements/base.txt
     #   unstructured
-packaging==22.0
+packaging==23.0
     # via
     #   -r requirements/base.txt
     #   argilla
@@ -441,12 +442,12 @@ packaging==22.0
     #   huggingface-hub
     #   ipykernel
     #   jupyter-server
-    #   limits
     #   matplotlib
     #   nbconvert
     #   onnxruntime
     #   pytesseract
     #   pytest
+    #   qtconsole
     #   qtpy
     #   transformers
 pandas==1.5.3
@@ -461,7 +462,7 @@ pandocfilters==1.5.0
     #   nbconvert
 parso==0.8.3
     # via jedi
-pathspec==0.11.0
+pathspec==0.11.1
     # via black
 pdf2image==1.16.3
     # via
@@ -494,7 +495,7 @@ pkgutil-resolve-name==1.3.10
     # via
     #   -r requirements/base.txt
     #   jsonschema
-platformdirs==3.0.0
+platformdirs==3.1.1
     # via
     #   -r requirements/base.txt
     #   black
@@ -514,7 +515,7 @@ prompt-toolkit==3.0.38
     # via
     #   ipython
     #   jupyter-console
-protobuf==4.22.0
+protobuf==4.22.1
     # via
     #   -r requirements/base.txt
     #   onnxruntime
@@ -536,7 +537,7 @@ pycparser==2.21
     # via
     #   -r requirements/base.txt
     #   cffi
-pydantic==1.10.5
+pydantic==1.10.6
     # via
     #   -r requirements/base.txt
     #   argilla
@@ -550,6 +551,11 @@ pygments==2.14.0
     #   jupyter-console
     #   nbconvert
     #   qtconsole
+    #   rich
+pypandoc==1.11
+    # via
+    #   -r requirements/base.txt
+    #   unstructured
 pyparsing==3.0.9
     # via
     #   -r requirements/base.txt
@@ -562,7 +568,7 @@ pytesseract==0.3.10
     # via
     #   -r requirements/base.txt
     #   layoutparser
-pytest==7.2.1
+pytest==7.2.2
     # via pytest-cov
 pytest-cov==4.0.0
     # via -r requirements/test.in
@@ -610,7 +616,7 @@ pyyaml==6.0
     #   timm
     #   transformers
     #   uvicorn
-pyzmq==25.0.0
+pyzmq==25.0.1
     # via
     #   -r requirements/base.txt
     #   ipykernel
@@ -620,7 +626,7 @@ pyzmq==25.0.0
     #   nbclassic
     #   notebook
     #   qtconsole
-qtconsole==5.4.0
+qtconsole==5.4.1
     # via jupyter
 qtpy==2.3.0
     # via qtconsole
@@ -650,6 +656,10 @@ rfc3986-validator==0.1.1
     # via
     #   jsonschema
     #   jupyter-events
+rich==13.0.1
+    # via
+    #   -r requirements/base.txt
+    #   argilla
 scipy==1.10.1
     # via
     #   -r requirements/base.txt
@@ -667,10 +677,6 @@ six==1.16.0
     #   bleach
     #   python-dateutil
     #   rfc3339-validator
-slowapi==0.1.7
-    # via
-    #   -r requirements/base.txt
-    #   unstructured-api-tools
 sniffio==1.3.0
     # via
     #   -r requirements/base.txt
@@ -683,7 +689,7 @@ soupsieve==2.4
     #   beautifulsoup4
 stack-data==0.6.2
     # via ipython
-starlette==0.25.0
+starlette==0.26.1
     # via
     #   -r requirements/base.txt
     #   fastapi
@@ -691,6 +697,7 @@ sympy==1.11.1
     # via
     #   -r requirements/base.txt
     #   onnxruntime
+    #   torch
 terminado==0.17.1
     # via
     #   jupyter-server
@@ -716,14 +723,14 @@ tomli==2.0.1
     #   coverage
     #   mypy
     #   pytest
-torch==1.13.1
+torch==2.0.0
     # via
     #   -r requirements/base.txt
     #   effdet
     #   layoutparser
     #   timm
     #   torchvision
-torchvision==0.14.1
+torchvision==0.15.1
     # via
     #   -r requirements/base.txt
     #   effdet
@@ -738,7 +745,7 @@ tornado==6.2
     #   nbclassic
     #   notebook
     #   terminado
-tqdm==4.64.1
+tqdm==4.65.0
     # via
     #   -r requirements/base.txt
     #   argilla
@@ -765,7 +772,7 @@ traitlets==5.9.0
     #   nbformat
     #   notebook
     #   qtconsole
-transformers==4.26.1
+transformers==4.27.1
     # via
     #   -r requirements/base.txt
     #   unstructured-inference
@@ -787,31 +794,26 @@ typing-extensions==4.5.0
     #   black
     #   huggingface-hub
     #   iopath
-    #   limits
     #   mypy
     #   pydantic
+    #   rich
     #   starlette
     #   torch
-    #   torchvision
-typish==1.9.3
-    # via
-    #   -r requirements/base.txt
-    #   jsons
-unstructured[local-inference]==0.5.0
+unstructured[local-inference]==0.5.4
     # via -r requirements/base.txt
-unstructured-api-tools==0.4.9
+unstructured-api-tools==0.5.0
     # via -r requirements/base.txt
-unstructured-inference==0.2.7
+unstructured-inference==0.2.11
     # via
     #   -r requirements/base.txt
     #   unstructured
 uri-template==1.2.0
     # via jsonschema
-urllib3==1.26.14
+urllib3==1.26.15
     # via
     #   -r requirements/base.txt
     #   requests
-uvicorn[standard]==0.20.0
+uvicorn[standard]==0.21.1
     # via
     #   -r requirements/base.txt
     #   unstructured-api-tools
@@ -845,7 +847,7 @@ websockets==10.4
     # via
     #   -r requirements/base.txt
     #   uvicorn
-wheel==0.38.4
+wheel==0.40.0
     # via astunparse
 widgetsnbextension==4.0.5
     # via ipywidgets
@@ -854,7 +856,7 @@ wrapt==1.14.1
     #   -r requirements/base.txt
     #   argilla
     #   deprecated
-xlsxwriter==3.0.8
+xlsxwriter==3.0.9
     # via
     #   -r requirements/base.txt
     #   python-pptx
@@ -866,4 +868,3 @@ zipp==3.15.0
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip
-# setuptools

--- a/scripts/smoketest.py
+++ b/scripts/smoketest.py
@@ -4,7 +4,7 @@ import time
 
 import pytest
 
-api_url = "http://localhost:8000/general/v0.0.4/general"
+api_url = "http://localhost:8000/general/v0.0.5/general"
 
 def send_document(filename):
     files = {"files": (str(filename), open(filename, "rb"), "text/plain")}

--- a/scripts/smoketest.py
+++ b/scripts/smoketest.py
@@ -4,11 +4,11 @@ import time
 
 import pytest
 
-api_url = "http://localhost:8000/general/v0.0.5/general"
+API_URL = "http://localhost:8000/general/v0/general"
 
 def send_document(filename):
     files = {"files": (str(filename), open(filename, "rb"), "text/plain")}
-    return requests.post(api_url, files=files)
+    return requests.post(API_URL, files=files)
 
 @pytest.mark.parametrize(
     "example_filename",

--- a/scripts/smoketest.py
+++ b/scripts/smoketest.py
@@ -37,8 +37,6 @@ def test_happy_path(example_filename):
     For the files in sample-docs, verify that we get a 200
     and some structured response
     """
-    time.sleep(1)  # Avoid a 429
-
     test_file = Path("sample-docs") / example_filename
     response = send_document(test_file)
 
@@ -47,5 +45,3 @@ def test_happy_path(example_filename):
     assert(response.status_code == 200)
     assert len(response.json()) > 0
     assert len("".join(elem["text"] for elem in response.json())) > 20
-
-    time.sleep(1)

--- a/test_general/api/test_app.py
+++ b/test_general/api/test_app.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-import time
 
 import pytest
 
@@ -13,8 +12,6 @@ MAIN_API_ROUTE = get_pipeline_path("general")
 
 
 def test_general_api_health_check():
-    # NOTE(robinson) - Reset the rate limit to avoid 429s in tests
-    app.state.limiter.reset()
     client = TestClient(app)
     response = client.get("/healthcheck")
 
@@ -41,11 +38,6 @@ def test_general_api_health_check():
     ],
 )
 def test_general_api(example_filename):
-    # NOTE(crag) - Reset below doesn't seem to be working, not sure why. But rate
-    # limiting will be removed soon anyway
-    time.sleep(1)
-    # NOTE(robinson) - Reset the rate limit to avoid 429s in tests
-    app.state.limiter.reset()
     client = TestClient(app)
     test_file = Path("sample-docs") / example_filename
     response = client.post(
@@ -54,4 +46,3 @@ def test_general_api(example_filename):
     assert response.status_code == 200
     assert len(response.json()) > 0
     assert len("".join(elem["text"] for elem in response.json())) > 20
-    time.sleep(1)

--- a/test_general/api/test_app.py
+++ b/test_general/api/test_app.py
@@ -50,8 +50,11 @@ def test_general_api(example_filename):
     # Just hit the second path (posting multiple files) to bump the coverage
     # We'll come back and make smarter tests
     response = client.post(
-        MAIN_API_ROUTE, files=[("files", (str(test_file), open(test_file, "rb"), "text/plain")),
-                               ("files", (str(test_file), open(test_file, "rb"), "text/plain"))]
+        MAIN_API_ROUTE,
+        files=[
+            ("files", (str(test_file), open(test_file, "rb"), "text/plain")),
+            ("files", (str(test_file), open(test_file, "rb"), "text/plain")),
+        ],
     )
     assert response.status_code == 200
     assert len(response.json()) > 0

--- a/test_general/api/test_app.py
+++ b/test_general/api/test_app.py
@@ -46,3 +46,12 @@ def test_general_api(example_filename):
     assert response.status_code == 200
     assert len(response.json()) > 0
     assert len("".join(elem["text"] for elem in response.json())) > 20
+
+    # Just hit the second path (posting multiple files) to bump the coverage
+    # We'll come back and make smarter tests
+    response = client.post(
+        MAIN_API_ROUTE, files=[("files", (str(test_file), open(test_file, "rb"), "text/plain")),
+                               ("files", (str(test_file), open(test_file, "rb"), "text/plain"))]
+    )
+    assert response.status_code == 200
+    assert len(response.json()) > 0


### PR DESCRIPTION
Follow up now that https://github.com/Unstructured-IO/unstructured-api-tools/pull/141 is merged.

This is a big diff, but for the record this is just:
* Bump unstructured-api-tools (and unstructured) in base.in
* Run `make pip-compile` to regen requirements files and `make install`
* Run `make generate-api`
* Remove the time.sleep lines from the tests