### PR TITLE
feat: add an m_strategy parameter to pipeline_api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 0.0.9-dev0
+## 0.0.9-dev1
 
 * Updated detectron version
+* Adds a strategy parameter to pipeline_api 
 
 ## 0.0.8
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ For example:
   | jq -C . | less -R
 ```
 
-We have two strategies for processing PDF files: `hi_res` and `fast`. `hi_res` takes a bit longer but provides better quality results. You can specify which you prefer with the `strategy` parameter.
+We have two strategies for processing PDF files: `hi_res` and `fast`. `hi_res` takes longer but provides better quality results. Conversely, `fast` is ideal for scenarios where time-to-result is the priority (`fast` is also the default)  You can specify which you prefer with the `strategy` parameter.
 
 ```
  curl -X 'POST' \

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ We have two strategies for processing PDF files: `hi_res` and `fast`. `hi_res` t
   -H 'accept: application/json' \
   -H 'Content-Type: multipart/form-data' \
   -F 'files=@sample-docs/layout-parser-paper.pdf' \
+  -F 'strategy=hi_res' \
   | jq -C . | less -R
 ```
 

--- a/README.md
+++ b/README.md
@@ -41,11 +41,21 @@ For example:
   'http://localhost:8000/general/v0/general' \
   -H 'accept: application/json' \
   -H 'Content-Type: multipart/form-data' \
-  -F 'files=@family-day.eml' \
+  -F 'files=@sample-docs/family-day.eml' \
   | jq -C . | less -R
 ```
 
-It's also nice to show how to call the API function using pure Python.
+We have two strategies for processing PDF files: `hi_res` and `fast`. `hi_res` takes a bit longer but provides better quality results. You can specify which you prefer with the `strategy` parameter.
+
+```
+ curl -X 'POST' \
+  'http://localhost:8000/general/v0/general' \
+  -H 'accept: application/json' \
+  -H 'Content-Type: multipart/form-data' \
+  -F 'files=@sample-docs/layout-parser-paper.pdf' \
+  | jq -C . | less -R
+```
+
 
 ### Generating Python files from the pipeline notebooks
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ For example:
   | jq -C . | less -R
 ```
 
-We have two strategies for processing PDF files: `hi_res` and `fast`. `hi_res` takes longer but provides better quality results. Conversely, `fast` is ideal for scenarios where time-to-result is the priority (`fast` is also the default)  You can specify which you prefer with the `strategy` parameter.
+We have two strategies for processing PDF files: `hi_res` and `fast`. `hi_res` takes longer but provides better quality results. Conversely, `fast` is ideal for scenarios where time-to-results is the priority (`fast` is also the default)  You can specify which you prefer with the `strategy` parameter.
 
 ```
  curl -X 'POST' \

--- a/pipeline-notebooks/pipeline-general.ipynb
+++ b/pipeline-notebooks/pipeline-general.ipynb
@@ -558,7 +558,6 @@
     "        _filename = os.path.join(tmpdir, filename.split('/')[-1])\n",
     "        with open(_filename, \"wb\") as f:\n",
     "            f.write(file.read())\n",
-    "        print(f\"route strategy: {strategy}\")\n",
     "        elements = partition(filename=_filename, strategy=strategy)\n",
     "    \n",
     "    # Due to the above, elements have an ugly temp filename in their metadata\n",

--- a/pipeline-notebooks/pipeline-general.ipynb
+++ b/pipeline-notebooks/pipeline-general.ipynb
@@ -44,7 +44,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "71814e12",
    "metadata": {},
    "outputs": [],
@@ -68,7 +68,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "72f0ebc4",
    "metadata": {},
    "outputs": [],
@@ -78,7 +78,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "ff34cce7",
    "metadata": {},
    "outputs": [],
@@ -98,7 +98,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "9925f0bf",
    "metadata": {},
    "outputs": [
@@ -185,7 +185,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "5769a88f",
    "metadata": {},
    "outputs": [
@@ -227,7 +227,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "11573046",
    "metadata": {},
    "outputs": [],
@@ -239,24 +239,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "ab65b4e5",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[<unstructured.documents.html.HTMLText>,\n",
-       " <unstructured.documents.html.HTMLNarrativeText>,\n",
-       " <unstructured.documents.html.HTMLNarrativeText>,\n",
-       " <unstructured.documents.html.HTMLNarrativeText>,\n",
-       " <unstructured.documents.html.HTMLTitle>,\n",
-       " <unstructured.documents.html.HTMLTitle>,\n",
-       " <unstructured.documents.html.HTMLTitle>,\n",
-       " <unstructured.documents.html.HTMLTitle>]"
+       "[<unstructured.documents.html.HTMLText at 0x149d4cc40>,\n",
+       " <unstructured.documents.html.HTMLNarrativeText at 0x149d4cd30>,\n",
+       " <unstructured.documents.html.HTMLNarrativeText at 0x149d4cdf0>,\n",
+       " <unstructured.documents.html.HTMLNarrativeText at 0x149d4cdc0>,\n",
+       " <unstructured.documents.html.HTMLTitle at 0x149d4ce50>,\n",
+       " <unstructured.documents.html.HTMLTitle at 0x2b3723970>,\n",
+       " <unstructured.documents.html.HTMLTitle at 0x2b37238e0>,\n",
+       " <unstructured.documents.html.HTMLTitle at 0x2b3723880>]"
       ]
      },
-     "execution_count": null,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -267,7 +267,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "fd3b23d0",
    "metadata": {},
    "outputs": [
@@ -285,7 +285,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "5eefd575",
    "metadata": {},
    "outputs": [
@@ -319,31 +319,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "9eca4b0f",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[<unstructured.documents.email_elements.MetaData>,\n",
-       " <unstructured.documents.email_elements.MetaData>,\n",
-       " <unstructured.documents.email_elements.MetaData>,\n",
-       " <unstructured.documents.email_elements.Subject>,\n",
-       " <unstructured.documents.email_elements.Sender>,\n",
-       " <unstructured.documents.email_elements.Recipient>,\n",
-       " <unstructured.documents.email_elements.MetaData>,\n",
-       " <unstructured.documents.html.HTMLText>,\n",
-       " <unstructured.documents.html.HTMLNarrativeText>,\n",
-       " <unstructured.documents.html.HTMLNarrativeText>,\n",
-       " <unstructured.documents.html.HTMLNarrativeText>,\n",
-       " <unstructured.documents.html.HTMLTitle>,\n",
-       " <unstructured.documents.html.HTMLTitle>,\n",
-       " <unstructured.documents.html.HTMLTitle>,\n",
-       " <unstructured.documents.html.HTMLTitle>]"
+       "[<unstructured.documents.email_elements.MetaData at 0x2b56de790>,\n",
+       " <unstructured.documents.email_elements.MetaData at 0x2b56de7f0>,\n",
+       " <unstructured.documents.email_elements.MetaData at 0x2b56de250>,\n",
+       " <unstructured.documents.email_elements.Subject at 0x2b56de880>,\n",
+       " <unstructured.documents.email_elements.Sender at 0x2b56dec40>,\n",
+       " <unstructured.documents.email_elements.Recipient at 0x2b56decd0>,\n",
+       " <unstructured.documents.email_elements.MetaData at 0x2b56de580>,\n",
+       " <unstructured.documents.html.HTMLText at 0x2b56de9d0>,\n",
+       " <unstructured.documents.html.HTMLNarrativeText at 0x2b56dea00>,\n",
+       " <unstructured.documents.html.HTMLNarrativeText at 0x2b56de730>,\n",
+       " <unstructured.documents.html.HTMLNarrativeText at 0x2b56dea30>,\n",
+       " <unstructured.documents.html.HTMLTitle at 0x2b56dea60>,\n",
+       " <unstructured.documents.html.HTMLTitle at 0x2b56deac0>,\n",
+       " <unstructured.documents.html.HTMLTitle at 0x2b56deaf0>,\n",
+       " <unstructured.documents.html.HTMLTitle at 0x2b56deb20>]"
       ]
      },
-     "execution_count": null,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -378,7 +378,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "id": "268e7dcd",
    "metadata": {},
    "outputs": [
@@ -388,7 +388,7 @@
        "'Hi All,'"
       ]
      },
-     "execution_count": null,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -400,7 +400,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "id": "485198a5",
    "metadata": {},
    "outputs": [
@@ -410,7 +410,7 @@
        "'Hi All,'"
       ]
      },
-     "execution_count": null,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -423,7 +423,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "id": "ed0b4a60",
    "metadata": {},
    "outputs": [
@@ -453,7 +453,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "id": "a4cb2037",
    "metadata": {},
    "outputs": [
@@ -463,7 +463,7 @@
        "'There will be face painting, a petting zoo, funnel cake and more.'"
       ]
      },
-     "execution_count": null,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -474,7 +474,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "id": "4f41f82c",
    "metadata": {},
    "outputs": [
@@ -497,7 +497,7 @@
        "   'ref_id': 'd69b468e295fa01cdb3b7c3f0bd34114'}}]"
       ]
      },
-     "execution_count": null,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -521,7 +521,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 28,
    "id": "d079cb81",
    "metadata": {},
    "outputs": [],
@@ -534,13 +534,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "id": "ab359aa7",
    "metadata": {},
    "outputs": [],
    "source": [
     "# pipeline-api\n",
-    "def pipeline_api(file, filename='', response_type=\"application/json\"):\n",
+    "def pipeline_api(file, filename='', m_strategy=[], response_type=\"application/json\"):\n",
+    "    strategy=(m_strategy[0] if len(m_strategy) else 'fast').lower()\n",
+    "    if strategy not in ['fast', 'hi_res']:\n",
+    "        raise HTTPException(\n",
+    "            status_code=400,\n",
+    "            detail=f\"Invalid strategy: {strategy}. Must be one of ['fast', 'hi_res']\"\n",
+    "        )\n",
     "    # NOTE(robinson) - This is a hacky solution due to\n",
     "    # limitations in the SpooledTemporaryFile wrapper.\n",
     "    # Specifically, it does't have a `seekable` attribute,\n",
@@ -552,7 +558,8 @@
     "        _filename = os.path.join(tmpdir, filename.split('/')[-1])\n",
     "        with open(_filename, \"wb\") as f:\n",
     "            f.write(file.read())\n",
-    "        elements = partition(filename=_filename)\n",
+    "        print(f\"route strategy: {strategy}\")\n",
+    "        elements = partition(filename=_filename, strategy=strategy)\n",
     "    \n",
     "    # Due to the above, elements have an ugly temp filename in their metadata\n",
     "    # For now, replace this with the basename\n",
@@ -565,7 +572,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "id": "19018f5a",
    "metadata": {},
    "outputs": [],
@@ -576,7 +583,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "id": "aa9d633e",
    "metadata": {},
    "outputs": [
@@ -625,7 +632,7 @@
        "  'metadata': {'filename': 'family-day.eml'}}]"
       ]
      },
-     "execution_count": null,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -644,7 +651,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 25,
    "id": "1657602a",
    "metadata": {},
    "outputs": [],
@@ -654,7 +661,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 26,
    "id": "0ec9e866",
    "metadata": {},
    "outputs": [],
@@ -665,7 +672,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 27,
    "id": "4dbefe9c",
    "metadata": {},
    "outputs": [
@@ -699,7 +706,7 @@
        "  'metadata': {'filename': 'fake-text.txt'}}]"
       ]
      },
-     "execution_count": null,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -714,6 +721,18 @@
    "display_name": "python3",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.15"
   }
  },
  "nbformat": 4,

--- a/pipeline-notebooks/pipeline-general.ipynb
+++ b/pipeline-notebooks/pipeline-general.ipynb
@@ -44,7 +44,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "71814e12",
    "metadata": {},
    "outputs": [],
@@ -68,7 +68,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "72f0ebc4",
    "metadata": {},
    "outputs": [],
@@ -78,7 +78,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "ff34cce7",
    "metadata": {},
    "outputs": [],
@@ -98,7 +98,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "9925f0bf",
    "metadata": {},
    "outputs": [
@@ -185,7 +185,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "5769a88f",
    "metadata": {},
    "outputs": [
@@ -227,7 +227,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "11573046",
    "metadata": {},
    "outputs": [],
@@ -239,24 +239,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "ab65b4e5",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[<unstructured.documents.html.HTMLText at 0x149d4cc40>,\n",
-       " <unstructured.documents.html.HTMLNarrativeText at 0x149d4cd30>,\n",
-       " <unstructured.documents.html.HTMLNarrativeText at 0x149d4cdf0>,\n",
-       " <unstructured.documents.html.HTMLNarrativeText at 0x149d4cdc0>,\n",
-       " <unstructured.documents.html.HTMLTitle at 0x149d4ce50>,\n",
-       " <unstructured.documents.html.HTMLTitle at 0x2b3723970>,\n",
-       " <unstructured.documents.html.HTMLTitle at 0x2b37238e0>,\n",
-       " <unstructured.documents.html.HTMLTitle at 0x2b3723880>]"
+       "[<unstructured.documents.html.HTMLText>,\n",
+       " <unstructured.documents.html.HTMLNarrativeText>,\n",
+       " <unstructured.documents.html.HTMLNarrativeText>,\n",
+       " <unstructured.documents.html.HTMLNarrativeText>,\n",
+       " <unstructured.documents.html.HTMLTitle>,\n",
+       " <unstructured.documents.html.HTMLTitle>,\n",
+       " <unstructured.documents.html.HTMLTitle>,\n",
+       " <unstructured.documents.html.HTMLTitle>]"
       ]
      },
-     "execution_count": 9,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -267,7 +267,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "fd3b23d0",
    "metadata": {},
    "outputs": [
@@ -285,7 +285,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "5eefd575",
    "metadata": {},
    "outputs": [
@@ -319,31 +319,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "9eca4b0f",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[<unstructured.documents.email_elements.MetaData at 0x2b56de790>,\n",
-       " <unstructured.documents.email_elements.MetaData at 0x2b56de7f0>,\n",
-       " <unstructured.documents.email_elements.MetaData at 0x2b56de250>,\n",
-       " <unstructured.documents.email_elements.Subject at 0x2b56de880>,\n",
-       " <unstructured.documents.email_elements.Sender at 0x2b56dec40>,\n",
-       " <unstructured.documents.email_elements.Recipient at 0x2b56decd0>,\n",
-       " <unstructured.documents.email_elements.MetaData at 0x2b56de580>,\n",
-       " <unstructured.documents.html.HTMLText at 0x2b56de9d0>,\n",
-       " <unstructured.documents.html.HTMLNarrativeText at 0x2b56dea00>,\n",
-       " <unstructured.documents.html.HTMLNarrativeText at 0x2b56de730>,\n",
-       " <unstructured.documents.html.HTMLNarrativeText at 0x2b56dea30>,\n",
-       " <unstructured.documents.html.HTMLTitle at 0x2b56dea60>,\n",
-       " <unstructured.documents.html.HTMLTitle at 0x2b56deac0>,\n",
-       " <unstructured.documents.html.HTMLTitle at 0x2b56deaf0>,\n",
-       " <unstructured.documents.html.HTMLTitle at 0x2b56deb20>]"
+       "[<unstructured.documents.email_elements.MetaData>,\n",
+       " <unstructured.documents.email_elements.MetaData>,\n",
+       " <unstructured.documents.email_elements.MetaData>,\n",
+       " <unstructured.documents.email_elements.Subject>,\n",
+       " <unstructured.documents.email_elements.Sender>,\n",
+       " <unstructured.documents.email_elements.Recipient>,\n",
+       " <unstructured.documents.email_elements.MetaData>,\n",
+       " <unstructured.documents.html.HTMLText>,\n",
+       " <unstructured.documents.html.HTMLNarrativeText>,\n",
+       " <unstructured.documents.html.HTMLNarrativeText>,\n",
+       " <unstructured.documents.html.HTMLNarrativeText>,\n",
+       " <unstructured.documents.html.HTMLTitle>,\n",
+       " <unstructured.documents.html.HTMLTitle>,\n",
+       " <unstructured.documents.html.HTMLTitle>,\n",
+       " <unstructured.documents.html.HTMLTitle>]"
       ]
      },
-     "execution_count": 12,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -378,7 +378,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "268e7dcd",
    "metadata": {},
    "outputs": [
@@ -388,7 +388,7 @@
        "'Hi All,'"
       ]
      },
-     "execution_count": 13,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -400,7 +400,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "id": "485198a5",
    "metadata": {},
    "outputs": [
@@ -410,7 +410,7 @@
        "'Hi All,'"
       ]
      },
-     "execution_count": 14,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -423,7 +423,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "id": "ed0b4a60",
    "metadata": {},
    "outputs": [
@@ -453,7 +453,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "id": "a4cb2037",
    "metadata": {},
    "outputs": [
@@ -463,7 +463,7 @@
        "'There will be face painting, a petting zoo, funnel cake and more.'"
       ]
      },
-     "execution_count": 16,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -474,7 +474,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "id": "4f41f82c",
    "metadata": {},
    "outputs": [
@@ -497,7 +497,7 @@
        "   'ref_id': 'd69b468e295fa01cdb3b7c3f0bd34114'}}]"
       ]
      },
-     "execution_count": 17,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -521,7 +521,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "id": "d079cb81",
    "metadata": {},
    "outputs": [],
@@ -534,7 +534,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "id": "ab359aa7",
    "metadata": {},
    "outputs": [],
@@ -571,7 +571,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "id": "19018f5a",
    "metadata": {},
    "outputs": [],
@@ -582,7 +582,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "id": "aa9d633e",
    "metadata": {},
    "outputs": [
@@ -631,7 +631,7 @@
        "  'metadata': {'filename': 'family-day.eml'}}]"
       ]
      },
-     "execution_count": 21,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -650,7 +650,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "id": "1657602a",
    "metadata": {},
    "outputs": [],
@@ -660,7 +660,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "id": "0ec9e866",
    "metadata": {},
    "outputs": [],
@@ -671,7 +671,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "id": "4dbefe9c",
    "metadata": {},
    "outputs": [
@@ -705,7 +705,7 @@
        "  'metadata': {'filename': 'fake-text.txt'}}]"
       ]
      },
-     "execution_count": 27,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -720,18 +720,6 @@
    "display_name": "python3",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.15"
   }
  },
  "nbformat": 4,

--- a/prepline_general/api/general.py
+++ b/prepline_general/api/general.py
@@ -41,6 +41,7 @@ def is_expected_response_type(media_type, response_type):
         return False
 
 
+# pipeline-api
 def pipeline_api(file, filename="", m_strategy=[], response_type="application/json"):
     strategy = (m_strategy[0] if len(m_strategy) else "fast").lower()
     if strategy not in ["fast", "hi_res"]:

--- a/prepline_general/api/general.py
+++ b/prepline_general/api/general.py
@@ -59,7 +59,6 @@ def pipeline_api(file, filename="", m_strategy=[], response_type="application/js
         _filename = os.path.join(tmpdir, filename.split("/")[-1])
         with open(_filename, "wb") as f:
             f.write(file.read())
-        print(f"route strategy: {strategy}")
         elements = partition(filename=_filename, strategy=strategy)
 
     # Due to the above, elements have an ugly temp filename in their metadata

--- a/prepline_general/api/general.py
+++ b/prepline_general/api/general.py
@@ -41,8 +41,13 @@ def is_expected_response_type(media_type, response_type):
         return False
 
 
-# pipeline-api
-def pipeline_api(file, filename="", response_type="application/json"):
+def pipeline_api(file, filename="", m_strategy=[], response_type="application/json"):
+    strategy = (m_strategy[0] if len(m_strategy) else "fast").lower()
+    if strategy not in ["fast", "hi_res"]:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid strategy: {strategy}. Must be one of ['fast', 'hi_res']",
+        )
     # NOTE(robinson) - This is a hacky solution due to
     # limitations in the SpooledTemporaryFile wrapper.
     # Specifically, it does't have a `seekable` attribute,
@@ -54,7 +59,8 @@ def pipeline_api(file, filename="", response_type="application/json"):
         _filename = os.path.join(tmpdir, filename.split("/")[-1])
         with open(_filename, "wb") as f:
             f.write(file.read())
-        elements = partition(filename=_filename)
+        print(f"route strategy: {strategy}")
+        elements = partition(filename=_filename, strategy=strategy)
 
     # Due to the above, elements have an ugly temp filename in their metadata
     # For now, replace this with the basename
@@ -155,6 +161,7 @@ def pipeline_1(
     request: Request,
     files: Union[List[UploadFile], None] = File(default=None),
     output_format: Union[str, None] = Form(default=None),
+    strategy: List[str] = Form(default=[]),
 ):
     content_type = request.headers.get("Accept")
 
@@ -187,6 +194,7 @@ def pipeline_1(
 
                     response = pipeline_api(
                         _file,
+                        m_strategy=strategy,
                         response_type=media_type,
                         filename=file.filename,
                     )
@@ -209,6 +217,7 @@ def pipeline_1(
 
             response = pipeline_api(
                 _file,
+                m_strategy=strategy,
                 response_type=media_type,
                 filename=file.filename,
             )

--- a/scripts/smoketest.py
+++ b/scripts/smoketest.py
@@ -9,9 +9,9 @@ API_URL = "http://localhost:8000/general/v0/general"
 # NOTE(rniko): Skip inference tests if we're running on an emulated architecture
 skip_inference_tests = os.getenv("SKIP_INFERENCE_TESTS", "").lower() in {"true", "yes", "y", "1"}
 
-def send_document(filename):
+def send_document(filename, strategy="fast"):
     files = {"files": (str(filename), open(filename, "rb"), "text/plain")}
-    return requests.post(API_URL, files=files)
+    return requests.post(API_URL, files=files, data={"strategy": strategy})
 
 @pytest.mark.parametrize(
     "example_filename",
@@ -52,3 +52,23 @@ def test_happy_path(example_filename):
     assert(response.status_code == 200)
     assert len(response.json()) > 0
     assert len("".join(elem["text"] for elem in response.json())) > 20
+
+def test_strategy_performance():
+    """
+    For the files in sample-docs, verify that the fast strategy
+    is significantly faster than the hi_res strategy
+    """
+    performance_ratio = 4
+    test_file = Path("sample-docs") / "layout-parser-paper.pdf"
+
+    start_time = time.time()
+    response = send_document(test_file, strategy="hi_res")
+    hi_res_time = time.time() - start_time
+    assert(response.status_code == 200)
+
+    start_time = time.time()
+    response = send_document(test_file, strategy="fast")
+    fast_time = time.time() - start_time
+    assert(response.status_code == 200)
+
+    assert hi_res_time > performance_ratio * fast_time

--- a/test_general/api/test_app.py
+++ b/test_general/api/test_app.py
@@ -57,6 +57,7 @@ def test_general_api(example_filename):
     assert response.status_code == 200
     assert len(response.json()) > 0
 
+
 def test_strategy_param_400():
     """Verify that we get a 400 if we pass in a bad strategy"""
     client = TestClient(app)

--- a/test_general/api/test_app.py
+++ b/test_general/api/test_app.py
@@ -1,9 +1,7 @@
 from pathlib import Path
 
 import pytest
-
 from fastapi.testclient import TestClient
-
 from unstructured_api_tools.pipelines.api_conventions import get_pipeline_path
 
 from prepline_general.api.app import app
@@ -58,3 +56,14 @@ def test_general_api(example_filename):
     )
     assert response.status_code == 200
     assert len(response.json()) > 0
+
+def test_strategy_param_400():
+    """Verify that we get a 400 if we pass in a bad strategy"""
+    client = TestClient(app)
+    test_file = Path("sample-docs") / "layout-parser-paper.pdf"
+    response = client.post(
+        MAIN_API_ROUTE,
+        files=[("files", (str(test_file), open(test_file, "rb"), "text/plain"))],
+        data={"strategy": "not_a_strategy"},
+    )
+    assert response.status_code == 400


### PR DESCRIPTION
* adds an `m_strategy` parameter with a string default of [“fast”] to `pipeline_api`
* adds a smoke test that tests the timing of a PDF with both strategies and verifies `fast` is _much_ faster than `hi_res`
* adds a unit test that validates a 400 error for any other value for `strategy`
* adds README mention of this functionality

## Testing

I ran the new smoke test on both the local mac and a remote dev instance. Both were clear the 4x threshold that we're testing against.

- Run the app (`make run-web-app` or preferred method that runs on localhost)
- Run the smoke test: `PYTHONPATH=. pytest scripts/smoketest.py::test_strategy_performance`

You can test any request with:
```
curl -X 'POST' \
  'http://localhost:8000/general/v0/general' \
  -H 'accept: application/json' \
  -H 'Content-Type: multipart/form-data' \
  -F 'files=@sample-docs/layout-parser-paper.pdf' \
  -F 'strategy=hi_res' \ 
  | jq -C .
```
Currently you can see at a glance whether the hi_res or fast strategy is running by observing the output of the web-app. In the case of hi_res you will see progress bars and mention of `Loading the Tesseract OCR agent`