### PR TITLE
chore: bump api-tools version to get content_type fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 0.0.10-dev0
+## 0.0.11
 
 * Add caching from the registry for `make docker-build`
+* Add fix for empty content type error
 
 ## 0.0.10
 

--- a/prepline_general/api/app.py
+++ b/prepline_general/api/app.py
@@ -19,6 +19,6 @@ app = FastAPI(
 app.include_router(general_router)
 
 
-@app.get("/healthcheck", status_code=status.HTTP_200_OK)
+@app.get("/healthcheck", status_code=status.HTTP_200_OK, include_in_schema=False)
 def healthcheck(request: Request):
     return {"healthcheck": "HEALTHCHECK STATUS: EVERYTHING OK!"}

--- a/prepline_general/api/general.py
+++ b/prepline_general/api/general.py
@@ -213,7 +213,7 @@ def ungz_file(file: UploadFile) -> UploadFile:
 
 
 @router.post("/general/v0/general")
-@router.post("/general/v0.0.10/general")
+@router.post("/general/v0.0.11/general")
 def pipeline_1(
     request: Request,
     files: Union[List[UploadFile], None] = File(default=None),

--- a/prepline_general/api/general.py
+++ b/prepline_general/api/general.py
@@ -120,7 +120,7 @@ def get_validated_mimetype(file):
     return HTTP 400 for an invalid type.
     """
     content_type = file.content_type
-    if content_type == "application/octet-stream":
+    if not content_type or content_type == "application/octet-stream":
         content_type = mimetypes.guess_type(str(file.filename))[0]
 
         # Markdown mimetype is too new for the library - just hardcode that one in for now
@@ -308,11 +308,6 @@ def pipeline_1(
             content='Request parameter "files" is required.\n',
             status_code=status.HTTP_400_BAD_REQUEST,
         )
-
-
-@app.get("/healthcheck", status_code=status.HTTP_200_OK)
-def healthcheck(request: Request):
-    return {"healthcheck": "HEALTHCHECK STATUS: EVERYTHING OK!"}
 
 
 app.include_router(router)

--- a/preprocessing-pipeline-family.yaml
+++ b/preprocessing-pipeline-family.yaml
@@ -1,2 +1,2 @@
 name: general
-version: 0.0.10
+version: 0.0.11

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,13 +11,13 @@ anyio==3.6.2
     #   httpcore
     #   starlette
     #   watchfiles
-argilla==1.5.1
+argilla==1.6.0
     # via unstructured
 attrs==22.2.0
     # via jsonschema
 backoff==2.2.1
     # via argilla
-beautifulsoup4==4.12.1
+beautifulsoup4==4.12.2
     # via nbconvert
 bleach==6.0.0
     # via nbconvert
@@ -62,7 +62,7 @@ fastapi==0.95.0
     #   unstructured-inference
 fastjsonschema==2.16.3
     # via nbformat
-filelock==3.10.7
+filelock==3.11.0
     # via
     #   huggingface-hub
     #   torch
@@ -81,7 +81,7 @@ httptools==0.5.0
     # via uvicorn
 httpx==0.23.3
     # via argilla
-huggingface-hub==0.13.3
+huggingface-hub==0.13.4
     # via
     #   timm
     #   transformers
@@ -93,7 +93,7 @@ idna==3.4
     #   anyio
     #   requests
     #   rfc3986
-importlib-metadata==6.1.0
+importlib-metadata==6.3.0
     # via
     #   jupyter-client
     #   markdown
@@ -148,13 +148,13 @@ mpmath==1.3.0
     # via sympy
 msg-parser==1.2.0
     # via unstructured
-mypy==1.1.1
+mypy==1.2.0
     # via unstructured-api-tools
 mypy-extensions==1.0.0
     # via mypy
 nbclient==0.7.3
     # via nbconvert
-nbconvert==7.3.0
+nbconvert==7.3.1
     # via unstructured-api-tools
 nbformat==5.8.0
     # via
@@ -209,7 +209,7 @@ pdf2image==1.16.3
     # via layoutparser
 pdfminer-six==20221105
     # via pdfplumber
-pdfplumber==0.8.0
+pdfplumber==0.8.1
     # via layoutparser
 pillow==9.5.0
     # via
@@ -237,7 +237,7 @@ pydantic==1.10.7
     # via
     #   argilla
     #   fastapi
-pygments==2.14.0
+pygments==2.15.0
     # via
     #   nbconvert
     #   rich
@@ -368,7 +368,7 @@ typing-extensions==4.5.0
     #   torch
 unstructured[local-inference]==0.5.11
     # via -r requirements/base.in
-unstructured-api-tools==0.9.2
+unstructured-api-tools==0.9.3
     # via -r requirements/base.in
 unstructured-inference==0.3.2
     # via unstructured

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -19,7 +19,7 @@ appnope==0.1.3
     # via
     #   ipykernel
     #   ipython
-argilla==1.5.1
+argilla==1.6.0
     # via
     #   -r requirements/base.txt
     #   unstructured
@@ -42,14 +42,13 @@ attrs==22.2.0
     # via
     #   -r requirements/base.txt
     #   jsonschema
-    #   pytest
 backcall==0.2.0
     # via ipython
 backoff==2.2.1
     # via
     #   -r requirements/base.txt
     #   argilla
-beautifulsoup4==4.12.1
+beautifulsoup4==4.12.2
     # via
     #   -r requirements/base.txt
     #   nbconvert
@@ -98,7 +97,7 @@ contourpy==1.0.7
     # via
     #   -r requirements/base.txt
     #   matplotlib
-coverage[toml]==7.2.2
+coverage[toml]==7.2.3
     # via pytest-cov
 cryptography==40.0.1
     # via
@@ -148,7 +147,7 @@ fastjsonschema==2.16.3
     # via
     #   -r requirements/base.txt
     #   nbformat
-filelock==3.10.7
+filelock==3.11.0
     # via
     #   -r requirements/base.txt
     #   huggingface-hub
@@ -185,7 +184,7 @@ httpx==0.23.3
     # via
     #   -r requirements/base.txt
     #   argilla
-huggingface-hub==0.13.3
+huggingface-hub==0.13.4
     # via
     #   -r requirements/base.txt
     #   timm
@@ -202,7 +201,7 @@ idna==3.4
     #   jsonschema
     #   requests
     #   rfc3986
-importlib-metadata==6.1.0
+importlib-metadata==6.3.0
     # via
     #   -r requirements/base.txt
     #   jupyter-client
@@ -354,7 +353,7 @@ msg-parser==1.2.0
     # via
     #   -r requirements/base.txt
     #   unstructured
-mypy==1.1.1
+mypy==1.2.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.in
@@ -370,7 +369,7 @@ nbclient==0.7.3
     # via
     #   -r requirements/base.txt
     #   nbconvert
-nbconvert==7.3.0
+nbconvert==7.3.1
     # via
     #   -r requirements/base.txt
     #   jupyter
@@ -401,7 +400,7 @@ nltk==3.8.1
     # via
     #   -r requirements/base.txt
     #   unstructured
-notebook==6.5.3
+notebook==6.5.4
     # via jupyter
 notebook-shim==0.2.2
     # via nbclassic
@@ -480,7 +479,7 @@ pdfminer-six==20221105
     # via
     #   -r requirements/base.txt
     #   pdfplumber
-pdfplumber==0.8.0
+pdfplumber==0.8.1
     # via
     #   -r requirements/base.txt
     #   layoutparser
@@ -552,7 +551,7 @@ pydantic==1.10.7
     #   fastapi
 pyflakes==3.0.1
     # via flake8
-pygments==2.14.0
+pygments==2.15.0
     # via
     #   -r requirements/base.txt
     #   ipython
@@ -576,7 +575,7 @@ pytesseract==0.3.10
     # via
     #   -r requirements/base.txt
     #   layoutparser
-pytest==7.2.2
+pytest==7.3.0
     # via pytest-cov
 pytest-cov==4.0.0
     # via -r requirements/test.in
@@ -810,7 +809,7 @@ typing-extensions==4.5.0
     #   torch
 unstructured[local-inference]==0.5.11
     # via -r requirements/base.txt
-unstructured-api-tools==0.9.2
+unstructured-api-tools==0.9.3
     # via -r requirements/base.txt
 unstructured-inference==0.3.2
     # via

--- a/scripts/smoketest.py
+++ b/scripts/smoketest.py
@@ -11,7 +11,7 @@ skip_inference_tests = os.getenv("SKIP_INFERENCE_TESTS", "").lower() in {"true",
 
 
 def send_document(filename, content_type, strategy="fast"):
-    files = {"files": (str(filename), open(filename, "rb"), content_type)}
+    files = {"files": (str(filename), open(filename, "rb"))}
     return requests.post(API_URL, files=files, data={"strategy": strategy})
 
 


### PR DESCRIPTION
When requests doesn't specify a content type, the server recieves None, which should be handled like octet-stream. We can verify that by removing the content type arg from the smoke test. All filetypes come back with a 400 error until we introduce the fix.