### PR TITLE
Fixes issue where detectron2 would not install on OSX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,9 +20,14 @@ install-base: install-base-pip-packages install-nltk-models install-detectron
 .PHONY: install 
 install:install-base install-test
 
+.PHONY: install-tensorboard
+install-tensorboard:
+	@if [ ${OS} = "Darwin" ]; then\
+		python3 -m pip install tensorboard;\
+	fi
 
-.PHONY: install-detectron
-install-detectron:
+.PHONY: install-detectron2
+install-detectron2: install-tensorboard
 	python3 -m pip install "detectron2@git+https://github.com/facebookresearch/detectron2.git@e2ce8dc#egg=detectron2"
 
 .PHONY: install-base-pip-packages

--- a/Makefile
+++ b/Makefile
@@ -20,10 +20,11 @@ install-base: install-base-pip-packages install-nltk-models install-detectron
 .PHONY: install 
 install:install-base install-test
 
+# Need for Apple Silicon based Macs
 .PHONY: install-tensorboard
 install-tensorboard:
 	@if [ ${OS} = "Darwin" ]; then\
-		python3 -m pip install tensorboard;\
+		python3 -m pip install tensorboard>=2.12.2;\
 	fi
 
 .PHONY: install-detectron2

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ When elements are extracted from PDFs or images, it may be useful to get their b
 	`pyenv  virtualenv 3.8.15 document-processing` <br />
 	`pyenv activate document-processing`
 
-  - If you are parsing PDFs, run the following to install the `detectron2` model, which
+  - To install the `detectron2` model, which
   `unstructured` uses for layout detection:
     - make install-detectron2
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ When elements are extracted from PDFs or images, it may be useful to get their b
 	`pyenv  virtualenv 3.8.15 document-processing` <br />
 	`pyenv activate document-processing`
 
+  - If you are parsing PDFs, run the following to install the `detectron2` model, which
+  `unstructured` uses for layout detection:
+    - make install-detectron2
+
 See the [Unstructured Quick Start](https://github.com/Unstructured-IO/unstructured#eight_pointed_black_star-quick-start) for the many OS dependencies that are required, if the ability to process all file types is desired.
 
 * Run `make install`


### PR DESCRIPTION
Tested on Apple silicon based MacBook Pro. This installs tensorboard which is required on OSX and arm based cpu’s for detectron2.