### PR TITLE
Chore: Add config for unstructured.trace logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.16
+
+* Add config for unstructured.trace logger
+
 ## 0.0.15
 
 * Add msg and json types to supported 

--- a/logger_config.yaml
+++ b/logger_config.yaml
@@ -34,6 +34,11 @@ loggers:
     handlers:
       - standard_handler
     propagate: no
+  unstructured.trace:
+    level: CRITICAL
+    handlers:
+      - standard_handler
+    propagate: no
   unstructured_inference:
     level: DEBUG
     handlers:

--- a/prepline_general/api/app.py
+++ b/prepline_general/api/app.py
@@ -5,7 +5,6 @@
 
 
 from fastapi import FastAPI, Request, status
-import logging
 
 from .general import router as general_router
 
@@ -19,15 +18,6 @@ app = FastAPI(
 )
 
 app.include_router(general_router)
-
-
-# Filter out /healthcheck noise
-class HealthCheckFilter(logging.Filter):
-    def filter(self, record: logging.LogRecord) -> bool:
-        return record.getMessage().find("/healthcheck") == -1
-
-
-logging.getLogger("uvicorn.access").addFilter(HealthCheckFilter())
 
 
 @app.get("/healthcheck", status_code=status.HTTP_200_OK, include_in_schema=False)

--- a/prepline_general/api/app.py
+++ b/prepline_general/api/app.py
@@ -5,6 +5,7 @@
 
 
 from fastapi import FastAPI, Request, status
+import logging
 
 from .general import router as general_router
 
@@ -18,6 +19,15 @@ app = FastAPI(
 )
 
 app.include_router(general_router)
+
+
+# Filter out /healthcheck noise
+class HealthCheckFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        return record.getMessage().find("/healthcheck") == -1
+
+
+logging.getLogger("uvicorn.access").addFilter(HealthCheckFilter())
 
 
 @app.get("/healthcheck", status_code=status.HTTP_200_OK, include_in_schema=False)

--- a/prepline_general/api/general.py
+++ b/prepline_general/api/general.py
@@ -219,7 +219,7 @@ def ungz_file(file: UploadFile, gz_uncompressed_content_type=None) -> UploadFile
 
 
 @router.post("/general/v0/general")
-@router.post("/general/v0.0.16/general")
+@router.post("/general/v0.0.17/general")
 def pipeline_1(
     request: Request,
     gz_uncompressed_content_type: Optional[str] = Form(default=None),

--- a/prepline_general/api/general.py
+++ b/prepline_general/api/general.py
@@ -219,7 +219,7 @@ def ungz_file(file: UploadFile, gz_uncompressed_content_type=None) -> UploadFile
 
 
 @router.post("/general/v0/general")
-@router.post("/general/v0.0.17/general")
+@router.post("/general/v0.0.16/general")
 def pipeline_1(
     request: Request,
     gz_uncompressed_content_type: Optional[str] = Form(default=None),

--- a/preprocessing-pipeline-family.yaml
+++ b/preprocessing-pipeline-family.yaml
@@ -1,2 +1,2 @@
 name: general
-version: 0.0.15
+version: 0.0.16


### PR DESCRIPTION
### Summary
Config for `unstructured.trace` logger since it is added in the `unstructured` repo. The NLP `DEBUG` level log from `unstructured` logger is moved to `unstructured.trace` logger of `DETAIL` level.

### Test
* Install latest version of `unstructured` in your env with `install-project-local`
* Set logger level for `unstructured` logger to `DEBUG`
* Run  `make run-web-app` and make an API call

The log output will only contain `INFO` level logs. i.e,
```
2023-05-10 13:16:42,130 uvicorn.error INFO Application startup complete.
2023-05-10 13:16:46,388 127.0.0.1:62057 POST /general/v0/general HTTP/1.1 - 200 OK
```
To see the NLP `DEBUG` log, set logger level for `unstructured.trace` logger to `DEBUG` and run the test again. The log output should look like:
```
2023-05-10 13:19:13,751 unstructured.trace DETAIL Not narrative. Text exceeds cap ratio 0.5:

largest dataset ever for doc- In: 2019 International Conference on Document IEEE (Sep 2019).
2023-05-10 13:19:13,755 127.0.0.1:62066 POST /general/v0/general HTTP/1.1 - 200 OK
```
