### PR TITLE
chore: remove docx and pptx writing to file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -102,10 +102,6 @@ RUN python3.8 -m pip install pip==${PIP_VERSION} \
   && pip3.8 install --no-cache tensorboard>=2.12.2 \
   && pip3.8 install --no-cache "detectron2@git+https://github.com/facebookresearch/detectron2.git@e2ce8dc#egg=detectron2"
 
-# fix openssl issue
-RUN pip3.8 uninstall --yes urllib3 && \
-  pip3.8 install urllib3==1.25.11
-
 RUN python3.8 -c "import nltk; nltk.download('punkt')" && \
   python3.8 -c "import nltk; nltk.download('averaged_perceptron_tagger')" && \
   python3.8 -c "from unstructured.ingest.doc_processor.generalized import initialize; initialize()"

--- a/pipeline-notebooks/pipeline-general.ipynb
+++ b/pipeline-notebooks/pipeline-general.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "e908195c",
    "metadata": {},
@@ -9,6 +10,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "727614ba",
    "metadata": {},
@@ -35,6 +37,7 @@
    "source": []
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "3848e558",
    "metadata": {},
@@ -43,6 +46,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "01a62fe4",
    "metadata": {},
@@ -98,6 +102,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "63e3b32b",
    "metadata": {},
@@ -217,6 +222,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "15d69b6b",
    "metadata": {},
@@ -225,6 +231,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "5c9e618c",
    "metadata": {},
@@ -317,6 +324,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "258531fe",
    "metadata": {},
@@ -361,6 +369,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "10e1d3df",
    "metadata": {},
@@ -369,6 +378,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "52943c00",
    "metadata": {},
@@ -451,6 +461,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "0f7fea99",
    "metadata": {},
@@ -517,6 +528,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "cde38923",
    "metadata": {},
@@ -575,31 +587,17 @@
     "    show_coordinates_str = (m_coordinates[0] if len(m_coordinates) else \"false\").lower()\n",
     "    show_coordinates = show_coordinates_str == \"true\"\n",
     "    \n",
-    "    if filename.endswith((\".docx\", \".pptx\")):\n",
-    "        # NOTE(robinson) - This is a hacky solution due to\n",
-    "        # limitations in the SpooledTemporaryFile wrapper.\n",
-    "        # Specifically, it doesn't have a `seekable` attribute,\n",
-    "        # which is required for .pptx and .docx. See below\n",
-    "        # the link below\n",
-    "        # ref: https://stackoverflow.com/questions/47160211\n",
-    "        # /why-doesnt-tempfile-spooledtemporaryfile-implement-readable-writable-seekable\n",
-    "        with tempfile.TemporaryDirectory() as tmpdir:\n",
-    "            _filename = os.path.join(tmpdir, filename.split('/')[-1])\n",
-    "            with open(_filename, \"wb\") as f:\n",
-    "                f.write(file.read())\n",
-    "            elements = partition(filename=_filename, strategy=strategy)\n",
-    "    else:\n",
-    "        try:\n",
-    "            elements = partition(file=file,\n",
-    "                                 file_filename=filename,\n",
-    "                                 content_type=file_content_type,\n",
-    "                                 strategy=strategy)\n",
-    "        except ValueError as e:\n",
-    "            if 'Invalid file' in e.args[0]:\n",
-    "                raise HTTPException(status_code=400, detail=f\"{file_content_type} not currently supported\")\n",
-    "            raise e\n",
-    "        except pdfminer.pdfparser.PDFSyntaxError:\n",
-    "            raise HTTPException(status_code=400, detail=f\"{filename} does not appear to be a valid PDF\")\n",
+    "    try:\n",
+    "        elements = partition(file=file,\n",
+    "                                file_filename=filename,\n",
+    "                                content_type=file_content_type,\n",
+    "                                strategy=strategy)\n",
+    "    except ValueError as e:\n",
+    "        if 'Invalid file' in e.args[0]:\n",
+    "            raise HTTPException(status_code=400, detail=f\"{file_content_type} not currently supported\")\n",
+    "        raise e\n",
+    "    except pdfminer.pdfparser.PDFSyntaxError:\n",
+    "        raise HTTPException(status_code=400, detail=f\"{filename} does not appear to be a valid PDF\")\n",
     "\n",
     "    # Due to the above, elements have an ugly temp filename in their metadata\n",
     "    # For now, replace this with the basename\n",
@@ -709,6 +707,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "e997bff5",
    "metadata": {},


### PR DESCRIPTION
Since we now push docx and pptx files into BytesIO in unstructured we no longer need to write them to a temporary file in the pipeline.

Also we no longer need to attempt to downgrade urllib since we have openssl 1.1.1 install in the image build. Removes downgrade step.


* Undo special handling of docx and pptx getting written to temp file
* bonus: Undo revertting to urllib<2