### PR TITLE
chore: bumping api version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.18
+
+* Add optional CORS to api
+
 ## 0.0.17
 
 * Add config for unstructured.trace logger

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.0.18
 
-* Add optional CORS to api
+* Add optional CORS to api if os env var `ALLOWED_ORIGINS` is set
 
 ## 0.0.17
 

--- a/prepline_general/api/app.py
+++ b/prepline_general/api/app.py
@@ -6,6 +6,7 @@
 
 from fastapi import FastAPI, Request, status
 import logging
+import os
 
 from .general import router as general_router
 
@@ -17,6 +18,17 @@ app = FastAPI(
     docs_url="/general/docs",
     openapi_url="/general/openapi.json",
 )
+
+allowed_origins = os.environ.get("ALLOWED_ORIGINS", None)
+if allowed_origins:
+    from fastapi.middleware.cors import CORSMiddleware
+
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=allowed_origins,
+        allow_methods=["OPTIONS", "POST"],
+        allow_headers=["Content-Type"],
+    )
 
 app.include_router(general_router)
 

--- a/prepline_general/api/general.py
+++ b/prepline_general/api/general.py
@@ -203,7 +203,7 @@ def ungz_file(file: UploadFile, gz_uncompressed_content_type=None) -> UploadFile
 
 
 @router.post("/general/v0/general")
-@router.post("/general/v0.0.17/general")
+@router.post("/general/v0.0.18/general")
 def pipeline_1(
     request: Request,
     gz_uncompressed_content_type: Optional[str] = Form(default=None),

--- a/preprocessing-pipeline-family.yaml
+++ b/preprocessing-pipeline-family.yaml
@@ -1,2 +1,2 @@
 name: general
-version: 0.0.17
+version: 0.0.18

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,7 +11,7 @@ anyio==3.6.2
     #   httpcore
     #   starlette
     #   watchfiles
-argilla==1.6.0
+argilla==1.7.0
     # via unstructured
 attrs==23.1.0
     # via jsonschema
@@ -36,6 +36,7 @@ charset-normalizer==3.1.0
 click==8.1.3
     # via
     #   nltk
+    #   typer
     #   unstructured-api-tools
     #   uvicorn
 coloredlogs==15.0.1
@@ -56,7 +57,7 @@ effdet==0.3.0
     # via layoutparser
 et-xmlfile==1.1.0
     # via openpyxl
-fastapi==0.95.1
+fastapi==0.95.2
     # via
     #   unstructured-api-tools
     #   unstructured-inference
@@ -67,9 +68,9 @@ filelock==3.12.0
     #   huggingface-hub
     #   torch
     #   transformers
-flatbuffers==23.5.8
+flatbuffers==23.5.9
     # via onnxruntime
-fonttools==4.39.3
+fonttools==4.39.4
     # via matplotlib
 fsspec==2023.5.0
     # via huggingface-hub
@@ -150,7 +151,7 @@ mpmath==1.3.0
     # via sympy
 msg-parser==1.2.0
     # via unstructured
-mypy==1.2.0
+mypy==1.3.0
     # via unstructured-api-tools
 mypy-extensions==1.0.0
     # via mypy
@@ -227,11 +228,11 @@ pillow==9.5.0
     #   unstructured
 pkgutil-resolve-name==1.3.10
     # via jsonschema
-platformdirs==3.5.0
+platformdirs==3.5.1
     # via jupyter-core
 portalocker==2.7.0
     # via iopath
-protobuf==4.23.0
+protobuf==4.23.1
     # via onnxruntime
 pycocotools==2.0.6
     # via effdet
@@ -299,6 +300,8 @@ rfc3986[idna2008]==1.5.0
     # via httpx
 rich==13.0.1
     # via argilla
+safetensors==0.3.1
+    # via timm
 scipy==1.10.1
     # via layoutparser
 six==1.16.0
@@ -312,13 +315,13 @@ sniffio==1.3.0
     #   httpx
 soupsieve==2.4.1
     # via beautifulsoup4
-starlette==0.26.1
+starlette==0.27.0
     # via fastapi
-sympy==1.11.1
+sympy==1.12
     # via
     #   onnxruntime
     #   torch
-timm==0.6.13
+timm==0.9.2
     # via effdet
 tinycss2==1.2.1
     # via nbconvert
@@ -337,7 +340,7 @@ torchvision==0.15.2
     #   effdet
     #   layoutparser
     #   timm
-tornado==6.3.1
+tornado==6.3.2
     # via jupyter-client
 tqdm==4.65.0
     # via
@@ -353,13 +356,15 @@ traitlets==5.9.0
     #   nbclient
     #   nbconvert
     #   nbformat
-transformers==4.28.1
+transformers==4.29.2
     # via unstructured-inference
+typer==0.9.0
+    # via argilla
 types-requests==2.30.0.0
     # via unstructured-api-tools
 types-ujson==5.7.0.5
     # via unstructured-api-tools
-types-urllib3==1.26.25.12
+types-urllib3==1.26.25.13
     # via types-requests
 typing-extensions==4.5.0
     # via
@@ -370,9 +375,10 @@ typing-extensions==4.5.0
     #   rich
     #   starlette
     #   torch
-unstructured[local-inference]==0.6.5
+    #   typer
+unstructured[local-inference]==0.6.6
     # via -r requirements/base.in
-unstructured-api-tools==0.10.4
+unstructured-api-tools==0.10.5
     # via -r requirements/base.in
 unstructured-inference==0.4.4
     # via unstructured

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -19,7 +19,7 @@ appnope==0.1.3
     # via
     #   ipykernel
     #   ipython
-argilla==1.6.0
+argilla==1.7.0
     # via
     #   -r requirements/base.txt
     #   unstructured
@@ -81,6 +81,7 @@ click==8.1.3
     #   -r requirements/test.in
     #   black
     #   nltk
+    #   typer
     #   unstructured-api-tools
     #   uvicorn
 coloredlogs==15.0.1
@@ -133,7 +134,7 @@ execnb==0.1.5
     # via nbdev
 executing==1.2.0
     # via stack-data
-fastapi==0.95.1
+fastapi==0.95.2
     # via
     #   -r requirements/base.txt
     #   unstructured-api-tools
@@ -155,11 +156,11 @@ filelock==3.12.0
     #   transformers
 flake8==6.0.0
     # via -r requirements/test.in
-flatbuffers==23.5.8
+flatbuffers==23.5.9
     # via
     #   -r requirements/base.txt
     #   onnxruntime
-fonttools==4.39.3
+fonttools==4.39.4
     # via
     #   -r requirements/base.txt
     #   matplotlib
@@ -222,7 +223,7 @@ iopath==0.1.10
     # via
     #   -r requirements/base.txt
     #   layoutparser
-ipykernel==6.23.0
+ipykernel==6.23.1
     # via
     #   ipywidgets
     #   jupyter
@@ -357,7 +358,7 @@ msg-parser==1.2.0
     # via
     #   -r requirements/base.txt
     #   unstructured
-mypy==1.2.0
+mypy==1.3.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.in
@@ -507,7 +508,7 @@ pkgutil-resolve-name==1.3.10
     # via
     #   -r requirements/base.txt
     #   jsonschema
-platformdirs==3.5.0
+platformdirs==3.5.1
     # via
     #   -r requirements/base.txt
     #   black
@@ -527,7 +528,7 @@ prompt-toolkit==3.0.38
     # via
     #   ipython
     #   jupyter-console
-protobuf==4.23.0
+protobuf==4.23.1
     # via
     #   -r requirements/base.txt
     #   onnxruntime
@@ -672,6 +673,10 @@ rich==13.0.1
     # via
     #   -r requirements/base.txt
     #   argilla
+safetensors==0.3.1
+    # via
+    #   -r requirements/base.txt
+    #   timm
 scipy==1.10.1
     # via
     #   -r requirements/base.txt
@@ -701,11 +706,11 @@ soupsieve==2.4.1
     #   beautifulsoup4
 stack-data==0.6.2
     # via ipython
-starlette==0.26.1
+starlette==0.27.0
     # via
     #   -r requirements/base.txt
     #   fastapi
-sympy==1.11.1
+sympy==1.12
     # via
     #   -r requirements/base.txt
     #   onnxruntime
@@ -716,7 +721,7 @@ terminado==0.17.1
     #   jupyter-server-terminals
     #   nbclassic
     #   notebook
-timm==0.6.13
+timm==0.9.2
     # via
     #   -r requirements/base.txt
     #   effdet
@@ -748,7 +753,7 @@ torchvision==0.15.2
     #   effdet
     #   layoutparser
     #   timm
-tornado==6.3.1
+tornado==6.3.2
     # via
     #   -r requirements/base.txt
     #   ipykernel
@@ -784,10 +789,14 @@ traitlets==5.9.0
     #   nbformat
     #   notebook
     #   qtconsole
-transformers==4.28.1
+transformers==4.29.2
     # via
     #   -r requirements/base.txt
     #   unstructured-inference
+typer==0.9.0
+    # via
+    #   -r requirements/base.txt
+    #   argilla
 types-requests==2.30.0.0
     # via
     #   -r requirements/base.txt
@@ -796,7 +805,7 @@ types-ujson==5.7.0.5
     # via
     #   -r requirements/base.txt
     #   unstructured-api-tools
-types-urllib3==1.26.25.12
+types-urllib3==1.26.25.13
     # via
     #   -r requirements/base.txt
     #   types-requests
@@ -812,9 +821,10 @@ typing-extensions==4.5.0
     #   rich
     #   starlette
     #   torch
-unstructured[local-inference]==0.6.5
+    #   typer
+unstructured[local-inference]==0.6.6
     # via -r requirements/base.txt
-unstructured-api-tools==0.10.4
+unstructured-api-tools==0.10.5
     # via -r requirements/base.txt
 unstructured-inference==0.4.4
     # via


### PR DESCRIPTION
Bumping the version and running `make generate-api` to add CORS support to the API if `ALLOWED_ORIGINS` is set. https://github.com/Unstructured-IO/unstructured-api-tools/pull/172
