### PR TITLE
feat: Add pdf_processing_mode to enable running pdfs in parallel

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,11 @@ Try our hosted API! It's freely available to use with any of the filetypes liste
 
 #### PDF Strategies
 
-Two strategies are available for processing PDF files: `hi_res` and `fast`. `fast` is the default `strategy` and works well for documents that do not have text embedded in images.
+Three strategies are available for processing PDF files: `hi_res`, `fast`, and `auto`. `fast` is the default `strategy` and works well for documents that do not have text embedded in images.
 
 On the other hand, `hi_res` is the better choice for PDF's that may have text within embedded images, or for achieving greater precision of [element types](https://unstructured-io.github.io/unstructured/getting_started.html#document-elements) in the response JSON. Please be aware that, as of writing, `hi_res` requests may take 20 times longer to process compared to the`fast` option. See the example below for making a `hi_res` request.
+
+For the best of both worlds, `auto` will determine when a page can be extracted using `fast` mode, otherwise it will fall back to `hi_res`.
 
 ```
  curl -X 'POST' \
@@ -42,6 +44,9 @@ On the other hand, `hi_res` is the better choice for PDF's that may have text wi
   -F 'strategy=hi_res' \
   | jq -C . | less -R
 ```
+
+#### PDF Processing Mode
+The `pdf_processing_mode` parameter can be `parallel` or `serial` (the default). In `serial` mode, a pdf will be processed one page at a time. In `parallel` mode, each page will be asynchronously sent to our hosted api. As we work to optimize the `hi_res` strategy, this is a quick way to get faster processing of pdfs. Note that this mode is currently hardcoded to send documents to api.unstructured.io.
 
 #### Coordinates
 

--- a/pipeline-notebooks/pipeline-general.ipynb
+++ b/pipeline-notebooks/pipeline-general.ipynb
@@ -1,7 +1,6 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "e908195c",
    "metadata": {},
@@ -10,7 +9,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "727614ba",
    "metadata": {},
@@ -37,7 +35,6 @@
    "source": []
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "3848e558",
    "metadata": {},
@@ -46,7 +43,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "01a62fe4",
    "metadata": {},
@@ -102,7 +98,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "63e3b32b",
    "metadata": {},
@@ -222,7 +217,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "15d69b6b",
    "metadata": {},
@@ -231,7 +225,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "5c9e618c",
    "metadata": {},
@@ -324,7 +317,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "258531fe",
    "metadata": {},
@@ -369,7 +361,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "10e1d3df",
    "metadata": {},
@@ -378,7 +369,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "52943c00",
    "metadata": {},
@@ -461,7 +451,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "0f7fea99",
    "metadata": {},
@@ -528,7 +517,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "cde38923",
    "metadata": {},
@@ -547,6 +535,10 @@
    "source": [
     "# pipeline-api\n",
     "\n",
+    "from concurrent.futures import ThreadPoolExecutor\n",
+    "from functools import partial\n",
+    "from PyPDF2 import PdfReader, PdfWriter\n",
+    "from unstructured.partition.api import partition_via_api\n",
     "from unstructured.partition.auto import partition\n",
     "from unstructured.staging.base import convert_to_isd\n",
     "import tempfile\n",
@@ -576,25 +568,140 @@
     "                    \"application/vnd.oasis.opendocument.text,\"\n",
     "\n",
     "if not os.environ.get(\"UNSTRUCTURED_ALLOWED_MIMETYPES\", None):\n",
-    "    os.environ[\"UNSTRUCTURED_ALLOWED_MIMETYPES\"] =  DEFAULT_MIMETYPES\n",
+    "    os.environ[\"UNSTRUCTURED_ALLOWED_MIMETYPES\"] =  DEFAULT_MIMETYPES"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ce14efb7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# pipeline-api\n",
+    "\n",
+    "def get_pdf_splits(pdf, split_size=1):\n",
+    "    '''\n",
+    "    Given a pdf (PdfReader) with n pages, split it into pdfs each with split_size # of pages\n",
+    "    Return the files as a list of BytesIO\n",
+    "    '''\n",
+    "    split_pdfs = []\n",
+    "\n",
+    "    count = 0\n",
+    "\n",
+    "    while count < len(pdf.pages):\n",
+    "        new_pdf = PdfWriter()\n",
+    "        pdf_buffer = io.BytesIO()\n",
+    "\n",
+    "        end = count+split_size\n",
+    "        for page in pdf.pages[count : end]:\n",
+    "            new_pdf.add_page(page)\n",
+    "\n",
+    "        new_pdf.write(pdf_buffer)\n",
+    "        pdf_buffer.seek(0)\n",
+    "\n",
+    "        split_pdfs.append(pdf_buffer)\n",
+    "        count += split_size\n",
+    "\n",
+    "    return split_pdfs\n",
     "\n",
     "\n",
-    "def pipeline_api(file, filename='', m_strategy=[], m_coordinates=[], file_content_type=None, response_type=\"application/json\"):\n",
+    "def partition_file_via_api(file, **kwargs):\n",
+    "    '''\n",
+    "    Given a file-like, use partition_via_api to retrieve its elements.\n",
+    "    Hardcode sending it to api.unstructured.io for now.\n",
+    "    '''\n",
+    "    # Note (austin) - the correct thing is to call back to ourselves\n",
+    "    # using the request.url. We'll need to pass the Request into pipeline_api().\n",
+    "    # Same goes for any request context to pass on, i.e. the token\n",
+    "    request_url = \"https://api.unstructured.io/general/v0/general\"  \n",
+    "    \n",
+    "    try:\n",
+    "        # Note (austin) - consider using partition_multiple_via_api to cut down on traffic\n",
+    "        # This would serialize the work that we just tried to split up,\n",
+    "        # so we first need to parallelize multi file input\n",
+    "        elements = partition_via_api(\n",
+    "            file=file,\n",
+    "            api_url=request_url,\n",
+    "            **kwargs\n",
+    "        )\n",
+    "    except ValueError as e:\n",
+    "        # TODO (austin) - the status code comes back in an error message\n",
+    "        # Need to pull that back out and set it here\n",
+    "        raise HTTPException(status_code=500, detail=f\"{e}\")\n",
+    "\n",
+    "    return elements\n",
+    "\n",
+    "\n",
+    "def partition_pdf_splits(file, **kwargs):\n",
+    "    '''\n",
+    "    Split up a pdf and process in parallel by sending back into the api\n",
+    "    '''\n",
+    "    pages_per_pdf = 1\n",
+    "    pdf = PdfReader(file)\n",
+    "\n",
+    "    # If it's small enough, just process locally\n",
+    "    if len(pdf.pages) <= pages_per_pdf:\n",
+    "        return partition(\n",
+    "            file=file,\n",
+    "            **kwargs\n",
+    "       )\n",
+    "\n",
+    "    results = []\n",
+    "    pages = get_pdf_splits(pdf, split_size=pages_per_pdf)\n",
+    "    partition_func = partial(partition_file_via_api, **kwargs)\n",
+    "\n",
+    "    with ThreadPoolExecutor() as executor:\n",
+    "        for result in executor.map(partition_func, pages):\n",
+    "            results.extend(result)\n",
+    "\n",
+    "    return results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fcb5cc3f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# pipeline-api\n",
+    "\n",
+    "def pipeline_api(file, filename='', m_strategy=[], m_coordinates=[], m_pdf_processing_mode=[], file_content_type=None, response_type=\"application/json\"):\n",
     "    strategy = (m_strategy[0] if len(m_strategy) else 'fast').lower()\n",
-    "    if strategy not in ['fast', 'hi_res']:\n",
+    "    strategies = ['fast', 'hi_res', 'auto']\n",
+    "    if strategy not in strategies:\n",
     "        raise HTTPException(\n",
     "            status_code=400,\n",
-    "            detail=f\"Invalid strategy: {strategy}. Must be one of ['fast', 'hi_res']\"\n",
+    "            detail=f\"Invalid strategy: {strategy}. Must be one of {strategies}\"\n",
+    "        )\n",
+    "        \n",
+    "    pdf_processing_mode = (m_pdf_processing_mode[0] if len(m_pdf_processing_mode) else 'serial').lower()\n",
+    "    modes = ['parallel', 'serial']\n",
+    "    if pdf_processing_mode not in modes:\n",
+    "        raise HTTPException(\n",
+    "            status_code=400,\n",
+    "            detail=f\"Invalid processing mode: {pdf_processing_mode}. Must be one of {modes}\"\n",
     "        )\n",
     "        \n",
     "    show_coordinates_str = (m_coordinates[0] if len(m_coordinates) else \"false\").lower()\n",
     "    show_coordinates = show_coordinates_str == \"true\"\n",
     "    \n",
     "    try:\n",
-    "        elements = partition(file=file,\n",
-    "                                file_filename=filename,\n",
-    "                                content_type=file_content_type,\n",
-    "                                strategy=strategy)\n",
+    "        if file_content_type == \"application/pdf\" and pdf_processing_mode == \"parallel\":\n",
+    "            elements = partition_pdf_splits(\n",
+    "                file=file,\n",
+    "                file_filename=filename,\n",
+    "                content_type=file_content_type,\n",
+    "                strategy=strategy\n",
+    "            )\n",
+    "        else:\n",
+    "            elements = partition(\n",
+    "                file=file,\n",
+    "                file_filename=filename,\n",
+    "                content_type=file_content_type,\n",
+    "                strategy=strategy\n",
+    "            )\n",
     "    except ValueError as e:\n",
     "        if 'Invalid file' in e.args[0]:\n",
     "            raise HTTPException(status_code=400, detail=f\"{file_content_type} not currently supported\")\n",
@@ -602,11 +709,14 @@
     "    except pdfminer.pdfparser.PDFSyntaxError:\n",
     "        raise HTTPException(status_code=400, detail=f\"{filename} does not appear to be a valid PDF\")\n",
     "\n",
-    "    # Due to the above, elements have an ugly temp filename in their metadata\n",
-    "    # For now, replace this with the basename\n",
     "    result = convert_to_isd(elements)\n",
     "    for element in result:\n",
     "        element['metadata']['filename'] = os.path.basename(filename)\n",
+    "\n",
+    "        # TODO (austin) - partition_via_api always returns a filetype of json\n",
+    "        # If we've run a pdf in parallel mode, just change the type back for now\n",
+    "        if \"pdf\" in element[\"metadata\"][\"filename\"] and \"json\" in element[\"metadata\"][\"filetype\"]:\n",
+    "            element[\"metadata\"][\"filetype\"] = \"application/pdf\"\n",
     "        \n",
     "        if not show_coordinates:\n",
     "            del element['coordinates']\n",
@@ -726,7 +836,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "e997bff5",
    "metadata": {},
@@ -808,9 +917,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "python3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.15"
   }
  },
  "nbformat": 4,

--- a/test_general/api/test_app.py
+++ b/test_general/api/test_app.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 
+import json
 import pytest
+import requests
 from fastapi.testclient import TestClient
 from unstructured_api_tools.pipelines.api_conventions import get_pipeline_path
 
@@ -144,3 +146,84 @@ def test_general_api_returns_500_bad_pdf():
     assert response.json() == {"detail": f"{tmp.name} does not appear to be a valid PDF"}
     assert response.status_code == 400
     tmp.close()
+
+
+def test_parallel_mode_correct_result():
+    '''
+    Validate that splitting up the pages and sending to the api
+    returns the same result as usual
+    Note that this test makes calls to prod for now
+    '''
+    client = TestClient(app)
+    test_file = Path("sample-docs") / "layout-parser-paper.pdf"
+
+    response = client.post(
+        MAIN_API_ROUTE,
+        files=[("files", (str(test_file), open(test_file, "rb"), "application/pdf"))],
+        )
+
+    assert response.status_code == 200
+    result_serial = response.json()
+
+    response = client.post(
+        MAIN_API_ROUTE,
+        files=[("files", (str(test_file), open(test_file, "rb"), "application/pdf"))],
+        data={"pdf_processing_mode": "parallel"},
+       )
+
+    assert response.status_code == 200
+    result_parallel = response.json()
+
+    for pair in zip(result_serial, result_parallel):
+        print(json.dumps(pair, indent=2))
+        assert pair[0] == pair[1]
+
+
+class MockResponse:
+    def __init__(self, status_code):
+        self.status_code = status_code
+
+
+def test_parallel_mode_returns_errors(monkeypatch):
+    '''
+    If we get an error sending a page to the api, bubble it up
+    '''
+    monkeypatch.setattr(
+        requests,
+        "post",
+        lambda *args, **kwargs: MockResponse(status_code=500),
+    )
+
+    client = TestClient(app)
+    test_file = Path("sample-docs") / "layout-parser-paper.pdf"
+
+    response = client.post(
+        MAIN_API_ROUTE,
+        files=[("files", (str(test_file), open(test_file, "rb"), "application/pdf"))],
+        data={"pdf_processing_mode": "parallel"},
+        )
+
+    assert response.status_code == 500
+
+    # TODO (austin) - Right now any non 200 is going to turn into a 500
+    # because of how partition_via_api_works
+    # At the very least we can return a message with a bit more info
+    monkeypatch.setattr(
+        requests,
+        "post",
+        lambda *args, **kwargs: MockResponse(status_code=400),
+    )
+
+    client = TestClient(app)
+    test_file = Path("sample-docs") / "layout-parser-paper.pdf"
+
+    response = client.post(
+        MAIN_API_ROUTE,
+        files=[("files", (str(test_file), open(test_file, "rb"), "application/pdf"))],
+        data={"pdf_processing_mode": "parallel"},
+        )
+
+    assert response.status_code == 500
+    assert response.json() == {
+        "detail": "Received unexpected status code 400 from the API"
+    }


### PR DESCRIPTION
This is a quick win for parallel processing of pdfs. Adds a new `pdf_processing_mode` param to the api. Default is `serial`, but when the mode is `parallel`, we'll split pdfs into 1 page files and send each to the hosted api.

With our `layout-paser-paper.pdf`, I'm seeing a ~3x speedup when running `hi_res`. This clearly isn't the best we can do, but when the full file is taking ~90 seconds, we have to start somewhere.

## Limitations / things to note:
- The upstream url is hardcoded to api.unstructured.io. This should really be whatever url is used to access the initial server, which we can get from `Request.url`. This is a `api-tools` change to pass the Request object down.
- The hosted api is rate limited to 100 requests per 5 minutes. Considering that the 1 pdf above will fan out to 16 additional requests, we need to bump this. Alternatively, we can whitelist our ECS hosts to allow traffic from ourselves to exceed this. Figure this out before this is deployed.
- This PR exposes some limitations in `partition_via_api`:
  -  There's a bug where the element metadata has filetype json
  -  Errors from the upstream api look like this: `Received unexpected status code 400 from the API`. We should make it easier to propagate the status code, plus any details the api returned.

## Testing
Please try something other than `layout-paper-parser.pdf` to verify the response times. First, try your pdf against our api for `hi_res`:

```
curl 'https://api.unstructured.io/general/v0/general' \
--header 'Accept: application/json' \
--form 'files=@"~/test files/layout-parser-paper.pdf"' \
--form 'strategy="hi_res"'
```

Then, pull this branch and run `make run-web-app`. Try the same pdf locally, which will hit the hosted api in parallel (page size should be under 100 per the rate limiting).

```
curl --location 'http://localhost:8000/general/v0/general' \
--header 'Accept: application/json' \
--form 'files=@"~/test files/layout-parser-paper.pdf"' \
--form 'strategy="hi_res"' \
--form 'pdf_processing_mode="parallel"'
```

Do this with cli timing tool, or via postman, to confirm that you're seeing a speedup.