### PR TITLE
Chore: Add support for CSV files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.23
+
+* Add support for csv files
+
 ## 0.0.22
 
 * Add parallel processing mode for pages within a pdf

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repo implements a pre-processing pipeline for the following documents. Curr
 
 * Plaintext: `.txt`, `.eml`, `.html`, `.md`, `.json`, `.rtf`
 * Images: `.jpeg`, `.png`
-* Documents: `.doc`, `.docx`, `.ppt`, `.pptx`, `.pdf`, `.odt`, `.epub`
+* Documents: `.doc`, `.docx`, `.ppt`, `.pptx`, `.pdf`, `.odt`, `.epub`, `.csv`
 
 ## :rocket: Unstructured API
 

--- a/pipeline-notebooks/pipeline-general.ipynb
+++ b/pipeline-notebooks/pipeline-general.ipynb
@@ -565,7 +565,9 @@
     "                    \"text/html,message/rfc822,text/plain,image/png,\" \\\n",
     "                    \"application/epub,application/epub+zip,\" \\\n",
     "                    \"application/rtf,text/rtf,\" \\\n",
-    "                    \"application/vnd.oasis.opendocument.text,\"\n",
+    "                    \"application/vnd.oasis.opendocument.text,\" \\\n",
+    "                    \"text/csv,text/x-csv,application/csv,application/x-csv,\" \\\n",
+    "                    \"text/comma-separated-values,text/x-comma-separated-values,\"\n",
     "\n",
     "if not os.environ.get(\"UNSTRUCTURED_ALLOWED_MIMETYPES\", None):\n",
     "    os.environ[\"UNSTRUCTURED_ALLOWED_MIMETYPES\"] =  DEFAULT_MIMETYPES"

--- a/prepline_general/api/general.py
+++ b/prepline_general/api/general.py
@@ -56,6 +56,8 @@ DEFAULT_MIMETYPES = (
     "application/epub,application/epub+zip,"
     "application/rtf,text/rtf,"
     "application/vnd.oasis.opendocument.text,"
+    "text/csv,text/x-csv,application/csv,application/x-csv,"
+    "text/comma-separated-values,text/x-comma-separated-values,"
 )
 
 if not os.environ.get("UNSTRUCTURED_ALLOWED_MIMETYPES", None):
@@ -300,7 +302,7 @@ def ungz_file(file: UploadFile, gz_uncompressed_content_type=None) -> UploadFile
 
 
 @router.post("/general/v0/general")
-@router.post("/general/v0.0.22/general")
+@router.post("/general/v0.0.23/general")
 def pipeline_1(
     request: Request,
     gz_uncompressed_content_type: Optional[str] = Form(default=None),

--- a/preprocessing-pipeline-family.yaml
+++ b/preprocessing-pipeline-family.yaml
@@ -1,2 +1,2 @@
 name: general
-version: 0.0.22
+version: 0.0.23

--- a/sample-docs/stanley-cups.csv
+++ b/sample-docs/stanley-cups.csv
@@ -1,0 +1,5 @@
+Stanley Cups,,
+Team,Location,Stanley Cups
+Blues,STL,1
+Flyers,PHI,2
+Maple Leafs,TOR,13

--- a/scripts/smoketest.py
+++ b/scripts/smoketest.py
@@ -32,6 +32,7 @@ def send_document(filename, content_type, strategy="fast"):
         ("winter-sports.epub", "application/epub"),
         ("fake-doc.rtf", "application/rtf"),
         ("fake.odt", "application/vnd.oasis.opendocument.text"),
+        ("stanley-cups.csv", "application/csv"),
         pytest.param("fake-excel.xlsx", None, marks=pytest.mark.xfail(reason="not supported yet")),
         # Note(austin) The two inference calls will hang on mac with unsupported hardware error
         # Skip these with SKIP_INFERENCE_TESTS=true make docker-test


### PR DESCRIPTION
### Summary

Support csv in docker smoke tests

### Test
`make docker-start-api` then
```
curl -X 'POST' \
'http://localhost:8000/general/v0/general' \
-H 'accept: application/json' \
-H 'Content-Type: multipart/form-data' \
-F 'files=@sample-docs/stanley-cups.csv' \
 | jq -C . | less -R
```