### PR TITLE
chore: bump python to 3.8.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.25
+
+* Bump image to use python 3.8.17 instead of 3.8.15 
+
 ## 0.0.24
 
 * Add returning text/csv to pipeline_api

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:experimental
-FROM quay.io/unstructured-io/base-images:rocky8.7-1
+FROM quay.io/unstructured-io/base-images:rocky8.7-2
 
 # NOTE(crag): NB_USER ARG for mybinder.org compat:
 #             https://mybinder.readthedocs.io/en/latest/tutorials/dockerfile.html

--- a/README.md
+++ b/README.md
@@ -65,12 +65,12 @@ When elements are extracted from PDFs or images, it may be useful to get their b
 * Using `pyenv` to manage virtualenv's is recommended
 	* Mac install instructions. See [here](https://github.com/Unstructured-IO/community#mac--homebrew) for more detailed instructions.
 		* `brew install pyenv-virtualenv`
-	  * `pyenv install 3.8.15`
+	  * `pyenv install 3.8.17`
   * Linux instructions are available [here](https://github.com/Unstructured-IO/community#linux).
 
   * Create a virtualenv to work in and activate it, e.g. for one named `document-processing`:
 
-	`pyenv  virtualenv 3.8.15 document-processing` <br />
+	`pyenv  virtualenv 3.8.17 document-processing` <br />
 	`pyenv activate document-processing`
 
 See the [Unstructured Quick Start](https://github.com/Unstructured-IO/unstructured#eight_pointed_black_star-quick-start) for the many OS dependencies that are required, if the ability to process all file types is desired.

--- a/prepline_general/api/general.py
+++ b/prepline_general/api/general.py
@@ -310,7 +310,7 @@ def ungz_file(file: UploadFile, gz_uncompressed_content_type=None) -> UploadFile
 
 
 @router.post("/general/v0/general")
-@router.post("/general/v0.0.24/general")
+@router.post("/general/v0.0.25/general")
 def pipeline_1(
     request: Request,
     gz_uncompressed_content_type: Optional[str] = Form(default=None),

--- a/preprocessing-pipeline-family.yaml
+++ b/preprocessing-pipeline-family.yaml
@@ -1,2 +1,2 @@
 name: general
-version: 0.0.24
+version: 0.0.25


### PR DESCRIPTION
The images pushed to quay.io will now have python 3.8.17 rather than python 3.8.15.