### PR TITLE
Chore: deprecate pypdf2 and move it to pypdf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.27-dev0
+
+* Move PYPDF2 to pypdf since PYPDF2 is deprecated
+
 ## 0.0.26
 
 * Add support for `ocr_only` strategy and `ocr_languages` parameter

--- a/pipeline-notebooks/pipeline-general.ipynb
+++ b/pipeline-notebooks/pipeline-general.ipynb
@@ -537,7 +537,7 @@
     "\n",
     "from concurrent.futures import ThreadPoolExecutor\n",
     "from functools import partial\n",
-    "from PyPDF2 import PdfReader, PdfWriter\n",
+    "from pypdf import PdfReader, PdfWriter\n",
     "from unstructured.partition.api import partition_via_api\n",
     "from unstructured.partition.auto import partition\n",
     "from unstructured.staging.base import convert_to_isd, convert_to_dataframe\n",

--- a/prepline_general/api/general.py
+++ b/prepline_general/api/general.py
@@ -19,7 +19,7 @@ from typing import Optional, Mapping, Iterator, Tuple
 import secrets
 from concurrent.futures import ThreadPoolExecutor
 from functools import partial
-from PyPDF2 import PdfReader, PdfWriter
+from pypdf import PdfReader, PdfWriter
 from unstructured.partition.api import partition_via_api
 from unstructured.partition.auto import partition
 from unstructured.staging.base import convert_to_isd, convert_to_dataframe
@@ -321,7 +321,7 @@ def ungz_file(file: UploadFile, gz_uncompressed_content_type=None) -> UploadFile
 
 
 @router.post("/general/v0/general")
-@router.post("/general/v0.0.26/general")
+@router.post("/general/v0.0.27/general")
 def pipeline_1(
     request: Request,
     gz_uncompressed_content_type: Optional[str] = Form(default=None),

--- a/preprocessing-pipeline-family.yaml
+++ b/preprocessing-pipeline-family.yaml
@@ -1,2 +1,2 @@
 name: general
-version: 0.0.26
+version: 0.0.27

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -2,6 +2,6 @@ unstructured[local-inference]>=0.7.1
 unstructured-api-tools>=0.6.0
 ratelimit
 requests
-pypdf2
+pypdf
 
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -99,7 +99,7 @@ idna==3.4
     #   anyio
     #   requests
     #   rfc3986
-importlib-metadata==6.6.0
+importlib-metadata==6.7.0
     # via
     #   jupyter-client
     #   markdown
@@ -146,7 +146,7 @@ markupsafe==2.1.3
     #   nbconvert
 matplotlib==3.7.1
     # via pycocotools
-mistune==2.0.5
+mistune==3.0.1
     # via nbconvert
 monotonic==1.6
     # via argilla
@@ -160,7 +160,7 @@ mypy-extensions==1.0.0
     # via mypy
 nbclient==0.8.0
     # via nbconvert
-nbconvert==7.5.0
+nbconvert==7.6.0
     # via unstructured-api-tools
 nbformat==5.9.0
     # via
@@ -187,7 +187,7 @@ olefile==0.46
     # via msg-parser
 omegaconf==2.3.0
     # via effdet
-onnxruntime==1.15.0
+onnxruntime==1.15.1
     # via unstructured-inference
 opencv-python==4.7.0.72
     # via
@@ -233,7 +233,7 @@ pillow==9.5.0
     #   unstructured
 pkgutil-resolve-name==1.3.10
     # via jsonschema
-platformdirs==3.5.3
+platformdirs==3.6.0
     # via jupyter-core
 portalocker==2.7.0
     # via iopath
@@ -253,9 +253,9 @@ pygments==2.15.1
     #   rich
 pypandoc==1.11
     # via unstructured
-pyparsing==3.0.9
+pyparsing==3.1.0
     # via matplotlib
-pypdf2==3.0.1
+pypdf==3.10.0
     # via -r requirements/base.in
 pyrsistent==0.19.3
     # via jsonschema
@@ -383,7 +383,7 @@ typing-extensions==4.6.3
     #   iopath
     #   mypy
     #   pydantic
-    #   pypdf2
+    #   pypdf
     #   rich
     #   starlette
     #   torch

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -215,7 +215,7 @@ idna==3.4
     #   jsonschema
     #   requests
     #   rfc3986
-importlib-metadata==6.6.0
+importlib-metadata==6.7.0
     # via
     #   -r requirements/base.txt
     #   jupyter-client
@@ -270,7 +270,7 @@ joblib==1.2.0
     # via
     #   -r requirements/base.txt
     #   nltk
-jsonpointer==2.3
+jsonpointer==2.4
     # via jsonschema
 jsonschema[format-nongpl]==4.17.3
     # via
@@ -351,7 +351,7 @@ matplotlib-inline==0.1.6
     #   ipython
 mccabe==0.7.0
     # via flake8
-mistune==2.0.5
+mistune==3.0.1
     # via
     #   -r requirements/base.txt
     #   nbconvert
@@ -383,7 +383,7 @@ nbclient==0.8.0
     # via
     #   -r requirements/base.txt
     #   nbconvert
-nbconvert==7.5.0
+nbconvert==7.6.0
     # via
     #   -r requirements/base.txt
     #   jupyter
@@ -440,7 +440,7 @@ omegaconf==2.3.0
     # via
     #   -r requirements/base.txt
     #   effdet
-onnxruntime==1.15.0
+onnxruntime==1.15.1
     # via
     #   -r requirements/base.txt
     #   unstructured-inference
@@ -520,7 +520,7 @@ pkgutil-resolve-name==1.3.10
     # via
     #   -r requirements/base.txt
     #   jsonschema
-platformdirs==3.5.3
+platformdirs==3.6.0
     # via
     #   -r requirements/base.txt
     #   black
@@ -581,11 +581,11 @@ pypandoc==1.11
     # via
     #   -r requirements/base.txt
     #   unstructured
-pyparsing==3.0.9
+pyparsing==3.1.0
     # via
     #   -r requirements/base.txt
     #   matplotlib
-pypdf2==3.0.1
+pypdf==3.10.0
     # via -r requirements/base.txt
 pyrsistent==0.19.3
     # via
@@ -837,7 +837,7 @@ typing-extensions==4.6.3
     #   ipython
     #   mypy
     #   pydantic
-    #   pypdf2
+    #   pypdf
     #   rich
     #   starlette
     #   torch
@@ -883,7 +883,7 @@ webencodings==0.5.1
     #   -r requirements/base.txt
     #   bleach
     #   tinycss2
-websocket-client==1.5.3
+websocket-client==1.6.0
     # via jupyter-server
 websockets==11.0.3
     # via


### PR DESCRIPTION
### Summary
From warning:
```
../../.pyenv/versions/unstructured-api/lib/python3.8/site-packages/PyPDF2/_init _.py: 21
/Users/yumingl/.pyenv/versions/unstructured-api/lib/python3.8/site-packages/PyPDF2/ ease move to the pypdf library instead.
warnings.warn
_init_.py:21: DeprecationWarning: PyPDF2 is deprecated. Please move to the pypdf library instead.
```

### Test
no warning from `make test`