### PR TITLE
chore: update all bash scripts to use shebang: /usr/bin/env bash

### DIFF
--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 DOCKER_REPOSITORY="${DOCKER_REPOSITORY:-quay.io/unstructured-io/unstructured-api}"

--- a/scripts/docker-smoke-test.sh
+++ b/scripts/docker-smoke-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # docker-smoke-test.sh
 # Start the containerized api and run some end-to-end tests against it

--- a/scripts/shellcheck.sh
+++ b/scripts/shellcheck.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 find scripts -name "*.sh" -exec shellcheck {} +
 

--- a/scripts/version-sync.sh
+++ b/scripts/version-sync.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 function usage {
     echo "Usage: $(basename "$0") [-c] -f FILE_TO_CHANGE REPLACEMENT_FORMAT [-f FILE_TO_CHANGE REPLACEMENT_FORMAT ...]" 2>&1
     echo 'Synchronize files to latest version in source file'


### PR DESCRIPTION
Update all bash scripts with #!/bin/bash to use /usr/bin/env bash.
