### PR TITLE
build(image): docker build tweak for arm64

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,7 +3,6 @@ name: Build And Push Docker Image
 on:
   push:
     branches:
-      - main
 
 env:
   DOCKER_REPOSITORY: quay.io/unstructured-io/unstructured-api
@@ -53,6 +52,8 @@ jobs:
     steps:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
+      with:
+        driver: 'docker'
     - name: Checkout code
       uses: actions/checkout@v3
     - name: Login to Quay.io

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,6 +3,7 @@ name: Build And Push Docker Image
 on:
   push:
     branches:
+      - main
 
 env:
   DOCKER_REPOSITORY: quay.io/unstructured-io/unstructured-api


### PR DESCRIPTION
Fixes issue where arm64 docker builds were failing and preventing images from being published.
The latest main commit plus this branch (1st commit) has already been published in CI here: 
https://github.com/Unstructured-IO/unstructured-api/actions/runs/5428856738/jobs/9873551850