### PR TITLE
chore: Remove a misleading error in docker smoketest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.35-dev0
+
+* Fix a misleading error in make docker-test
+
 ## 0.0.34
 
 * Bump unstructured library to 0.9.0

--- a/prepline_general/api/general.py
+++ b/prepline_general/api/general.py
@@ -481,7 +481,7 @@ def ungz_file(file: UploadFile, gz_uncompressed_content_type=None) -> UploadFile
 
 
 @router.post("/general/v0/general")
-@router.post("/general/v0.0.34/general")
+@router.post("/general/v0.0.35/general")
 def pipeline_1(
     request: Request,
     gz_uncompressed_content_type: Optional[str] = Form(default=None),

--- a/preprocessing-pipeline-family.yaml
+++ b/preprocessing-pipeline-family.yaml
@@ -1,2 +1,2 @@
 name: general
-version: 0.0.34
+version: 0.0.35

--- a/scripts/docker-smoke-test.sh
+++ b/scripts/docker-smoke-test.sh
@@ -79,16 +79,16 @@ await_server_ready 8000
 # Smoke Tests
 #######################
 echo Running smoke tests
-# PYTHONPATH=. SKIP_INFERENCE_TESTS=$SKIP_INFERENCE_TESTS pytest scripts/smoketest.py
+PYTHONPATH=. SKIP_INFERENCE_TESTS=$SKIP_INFERENCE_TESTS pytest scripts/smoketest.py
 
 #######################
 # Test parallel vs single mode
 #######################
-# start_container 9000 true
-# await_server_ready 9000
+start_container 9000 true
+await_server_ready 9000
 
-# echo Running parallel mode test
-# ./scripts/parallel-mode-test.sh localhost:8000 localhost:9000
+echo Running parallel mode test
+./scripts/parallel-mode-test.sh localhost:8000 localhost:9000
 
 result=$?
 exit $result

--- a/scripts/docker-smoke-test.sh
+++ b/scripts/docker-smoke-test.sh
@@ -63,10 +63,10 @@ stop_container() {
     echo Stopping container "$CONTAINER_NAME"
     # Note (austin) - if you're getting an error from the api, try dumping the logs
     # docker logs $CONTAINER_NAME 2> docker_logs.txt
-    docker stop "$CONTAINER_NAME"
+    docker stop "$CONTAINER_NAME" 2> /dev/null || true
 
     echo Stopping container "$CONTAINER_NAME_PARALLEL"
-    docker stop "$CONTAINER_NAME_PARALLEL"
+    docker stop "$CONTAINER_NAME_PARALLEL" 2> /dev/null || true
 }
 
 # Always clean up the container
@@ -79,16 +79,16 @@ await_server_ready 8000
 # Smoke Tests
 #######################
 echo Running smoke tests
-PYTHONPATH=. SKIP_INFERENCE_TESTS=$SKIP_INFERENCE_TESTS pytest scripts/smoketest.py
+# PYTHONPATH=. SKIP_INFERENCE_TESTS=$SKIP_INFERENCE_TESTS pytest scripts/smoketest.py
 
 #######################
 # Test parallel vs single mode
 #######################
-start_container 9000 true
-await_server_ready 9000
+# start_container 9000 true
+# await_server_ready 9000
 
-echo Running parallel mode test
-./scripts/parallel-mode-test.sh localhost:8000 localhost:9000
+# echo Running parallel mode test
+# ./scripts/parallel-mode-test.sh localhost:8000 localhost:9000
 
 result=$?
 exit $result


### PR DESCRIPTION
Don't complain when stopping a container that doesn't exist.