### PR TITLE
fix: share the cache from the CI workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,7 +9,7 @@ env:
   DOCKER_REPOSITORY: quay.io/unstructured-io/unstructured-api
   DOCKER_BUILD_REPOSITORY: quay.io/unstructured-io/build-unstructured-api
   PACKAGE: "unstructured-api"
-  PIPELINE_PACKAGE: "general"
+  PIPELINE_FAMILY: "general"
   PIP_VERSION: "22.2.1"
   PYTHON_VERSION: "3.8"
 
@@ -72,7 +72,7 @@ jobs:
         DOCKER_BUILDKIT=1 docker buildx build --platform=$ARCH --load \
           --build-arg PIP_VERSION=$PIP_VERSION \
           --build-arg BUILDKIT_INLINE_CACHE=1 \
-          --build-arg PIPELINE_PACKAGE=${{ env.PIPELINE_PACKAGE }} \
+          --build-arg PIPELINE_PACKAGE=${{ env.PIPELINE_FAMILY }} \
           --provenance=false \
           --progress plain \
           --cache-from $DOCKER_BUILD_REPOSITORY:$ARCH \

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -66,7 +66,7 @@ jobs:
     - name: Build image
       run: |
         # Clear some space (https://github.com/actions/runner-images/issues/2840)
-        sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/share/boost "$AGENT_TOOLSDIRECTORY"
+        sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/share/boost
 
         ARCH=$(cut -d "/" -f2 <<< ${{ matrix.docker-platform }})
         DOCKER_BUILDKIT=1 docker buildx build --platform=$ARCH --load \


### PR DESCRIPTION
This isn't necessarily a fix for the missing .venv, but this will remove an extra 2GB cache called ci-venv--{commit} and reuse ci-venv-general-{commit}.

Also, don't delete the $AGENT_TOOLSDIRECTORY dir. Testing shows this is `/opt/hostedtoolcache`. No immediate connection to the cache action, which seems to use `/home/runner/work/_temp`, but I did manage to get past the bad interpreter error by keeping this dir.