### PR TITLE
fix: fix occasional UnboundLocalError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 0.0.38-dev0
+## 0.0.38-dev1
 
 * Fix page break has None page number bug
+* Fix a UnboundLocalError using pdfs in parallel mode
 
 ## 0.0.37
 

--- a/pipeline-notebooks/pipeline-general.ipynb
+++ b/pipeline-notebooks/pipeline-general.ipynb
@@ -773,7 +773,7 @@
     "        # since fast api might sent the wrong one.\n",
     "        file_content_type = \"application/x-ole-storage\"\n",
     "        \n",
-    "    if filename.endswith(\".pdf\"):\n",
+    "    if file_content_type == \"application/pdf\":\n",
     "        try: \n",
     "            pdf = PdfReader(file)\n",
     "        except pypdf.errors.EmptyFileError:\n",

--- a/pipeline-notebooks/pipeline-general.ipynb
+++ b/pipeline-notebooks/pipeline-general.ipynb
@@ -753,7 +753,6 @@
     "):\n",
     "    logger.debug(\"pipeline_api input params: {}\".format(\n",
     "        json.dumps({\n",
-    "        \"request\": request,\n",
     "        \"filename\": filename,\n",
     "        \"file_content_type\": file_content_type,\n",
     "        \"response_type\": response_type,\n",

--- a/prepline_general/api/general.py
+++ b/prepline_general/api/general.py
@@ -239,7 +239,7 @@ def pipeline_api(
         # since fast api might sent the wrong one.
         file_content_type = "application/x-ole-storage"
 
-    if filename.endswith(".pdf"):
+    if file_content_type == "application/pdf":
         try:
             pdf = PdfReader(file)
         except pypdf.errors.EmptyFileError:

--- a/prepline_general/api/general.py
+++ b/prepline_general/api/general.py
@@ -216,7 +216,6 @@ def pipeline_api(
         "pipeline_api input params: {}".format(
             json.dumps(
                 {
-                    "request": request,
                     "filename": filename,
                     "file_content_type": file_content_type,
                     "response_type": response_type,


### PR DESCRIPTION
To verify, you need to run parallel mode and send a pdf file with the correct mimetype but a wrong file extension.

On main, start the server in parallel mode and confirm the bug happens:
```
export UNSTRUCTURED_PARALLEL_MODE_ENABLED=true
export UNSTRUCTURED_PARALLEL_MODE_URL=http://localhost:8000/general/v0/general
make run-web-app
```

In a python shell:
```
import requests

with open("sample-docs/layout-parser-paper.pdf", "rb") as f:
    res = requests.post("http://localhost:8000/general/v0/general",
                files={"files": ("foo.txt", f, "application/pdf")})

    # Should be Internal server error
    print(res.text)

```

Then try again on this branch.

Also, removed logging of the request object, which just displays an object reference next to the params.