### PR TITLE
enhancement(deps): cut a release when unstructured libs are bumped

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,11 @@ updates:
   - package-ecosystem: "pip"
     directory: "/requirements"
     schedule:
-      interval: "weekly"
+      interval: "daily"
+    # Only use this to bump our libraries
+    allow:
+      - dependency-name: "unstructured*"
+        dependency-type: "direct"
 
   - package-ecosystem: "github-actions"
     # NOTE(robinson) - Workflow files stored in the

--- a/.github/workflows/bump_libraries.yaml
+++ b/.github/workflows/bump_libraries.yaml
@@ -2,20 +2,22 @@ name: Dependabot: Bump libs and cut release
 
 on:
   pull_request:
-    types: [opened, reopened]
+    types:
+      - opened
+      - reopened
     paths:
       - 'requirements/**'
 
 jobs:
     bump-changelog:
         runs-on: ubuntu-latest
-        # if: ${{ github.actor == 'dependabot[bot]' }}
+        if: ${{ github.actor == 'dependabot[bot]' }}
         steps:
-        # - name: Dependabot metadata
-        #   id: metadata
-        #   uses: dependabot/fetch-metadata@v1
-        #   with:
-        #     github-token: "${{ secrets.GITHUB_TOKEN }}"
+        - name: Dependabot metadata
+          id: metadata
+          uses: dependabot/fetch-metadata@v1
+          with:
+            github-token: "${{ secrets.GITHUB_TOKEN }}"
         - name: Create release version
           run: |
             changelog_message="Bump ${{ steps.metadata.outputs.dependency-names }} to ${{ steps.metadata.outputs.new-version }}"

--- a/.github/workflows/bump_libraries.yaml
+++ b/.github/workflows/bump_libraries.yaml
@@ -1,4 +1,4 @@
-name: Bump Unstructured Libraries
+name: Bump Unstructured deps and cut release
 
 on:
   push:

--- a/.github/workflows/bump_libraries.yaml
+++ b/.github/workflows/bump_libraries.yaml
@@ -21,5 +21,6 @@ jobs:
             ./scripts/version-increment.sh "$changelog_message"
             make version-sync
         - uses: stefanzweifel/git-auto-commit-action@v4
-          commit_message: "Bump libraries and release"
+          with:
+            commit_message: "Bump libraries and release"
 

--- a/.github/workflows/bump_libraries.yaml
+++ b/.github/workflows/bump_libraries.yaml
@@ -18,7 +18,7 @@ jobs:
         - name: Create release version
           run: |
             changelog_message="Bump ${{ steps.metadata.outputs.dependency-names }} to ${{ steps.metadata.outputs.new-version }}"
-            ./scripts/version-increment.sh $changelog_message
+            ./scripts/version-increment.sh "$changelog_message"
             make version-sync
             git commit -am "Bump api version"
         - uses: stefanzweifel/git-auto-commit-action@v4

--- a/.github/workflows/bump_libraries.yaml
+++ b/.github/workflows/bump_libraries.yaml
@@ -1,20 +1,21 @@
-name: Bump Unstructured deps and cut release
+name: Dependabot: Bump libs and cut release
 
 on:
-  push:
-    branches:
-      # - "dependabot/pip/**"
+  pull_request:
+    types: [opened, reopened]
+    paths:
+      - 'requirements/**'
 
 jobs:
     bump-changelog:
         runs-on: ubuntu-latest
         # if: ${{ github.actor == 'dependabot[bot]' }}
         steps:
-        - name: Dependabot metadata
-          id: metadata
-          uses: dependabot/fetch-metadata@v1
-          with:
-            github-token: "${{ secrets.GITHUB_TOKEN }}"
+        # - name: Dependabot metadata
+        #   id: metadata
+        #   uses: dependabot/fetch-metadata@v1
+        #   with:
+        #     github-token: "${{ secrets.GITHUB_TOKEN }}"
         - name: Create release version
           run: |
             changelog_message="Bump ${{ steps.metadata.outputs.dependency-names }} to ${{ steps.metadata.outputs.new-version }}"

--- a/.github/workflows/bump_libraries.yaml
+++ b/.github/workflows/bump_libraries.yaml
@@ -14,7 +14,7 @@ jobs:
           id: metadata
           uses: dependabot/fetch-metadata@v1
           with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
+            github-token: "${{ secrets.GITHUB_TOKEN }}"
         - name: Create release version
           run: |
             changelog_message="Bump ${{ steps.metadata.outputs.dependency-names }} to ${{ steps.metadata.outputs.new-version }}"

--- a/.github/workflows/bump_libraries.yaml
+++ b/.github/workflows/bump_libraries.yaml
@@ -1,0 +1,26 @@
+name: Bump Unstructured Libraries
+
+on:
+  push:
+    branches:
+      - "dependabot/pip/**"
+
+jobs:
+    bump-changelog:
+        runs-on: ubuntu-latest
+        if: ${{ github.actor == 'dependabot[bot]' }}
+        steps:
+        - name: Dependabot metadata
+            id: metadata
+            uses: dependabot/fetch-metadata@v1
+            with:
+            github-token: "${{ secrets.GITHUB_TOKEN }}"
+        - name: Create release version
+          run: |
+            changelog_message="Bump ${{ steps.metadata.outputs.dependency-names }} to ${{ steps.metadata.outputs.new-version }}"
+            ./scripts/version-increment.sh $changelog_message
+            make version-sync
+            git commit -am "Bump api version"
+        - uses: stefanzweifel/git-auto-commit-action@v4
+          commit_message: "Bump libraries and release"
+

--- a/.github/workflows/bump_libraries.yaml
+++ b/.github/workflows/bump_libraries.yaml
@@ -1,4 +1,4 @@
-name: Dependabot: Bump libs and cut release
+name: Dependabot - Bump libs and cut release
 
 on:
   pull_request:

--- a/.github/workflows/bump_libraries.yaml
+++ b/.github/workflows/bump_libraries.yaml
@@ -3,12 +3,12 @@ name: Bump Unstructured deps and cut release
 on:
   push:
     branches:
-      - "dependabot/pip/**"
+      # - "dependabot/pip/**"
 
 jobs:
     bump-changelog:
         runs-on: ubuntu-latest
-        if: ${{ github.actor == 'dependabot[bot]' }}
+        # if: ${{ github.actor == 'dependabot[bot]' }}
         steps:
         - name: Dependabot metadata
           id: metadata
@@ -20,7 +20,6 @@ jobs:
             changelog_message="Bump ${{ steps.metadata.outputs.dependency-names }} to ${{ steps.metadata.outputs.new-version }}"
             ./scripts/version-increment.sh "$changelog_message"
             make version-sync
-            git commit -am "Bump api version"
         - uses: stefanzweifel/git-auto-commit-action@v4
           commit_message: "Bump libraries and release"
 

--- a/.github/workflows/bump_libraries.yaml
+++ b/.github/workflows/bump_libraries.yaml
@@ -11,10 +11,10 @@ jobs:
         if: ${{ github.actor == 'dependabot[bot]' }}
         steps:
         - name: Dependabot metadata
-            id: metadata
-            uses: dependabot/fetch-metadata@v1
-            with:
-            github-token: "${{ secrets.GITHUB_TOKEN }}"
+          id: metadata
+          uses: dependabot/fetch-metadata@v1
+          with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
         - name: Create release version
           run: |
             changelog_message="Bump ${{ steps.metadata.outputs.dependency-names }} to ${{ steps.metadata.outputs.new-version }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.0.43-dev2
+## 0.0.43-dev3
 
 * Remove dependency on unstructured-api-tools
 * Add a top level error handler for more consistent response bodies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.0.43-dev1
+## 0.0.43-dev2
 
 * Remove dependency on unstructured-api-tools
 * Add a top level error handler for more consistent response bodies

--- a/scripts/version-increment.sh
+++ b/scripts/version-increment.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+function usage {
+    echo "Usage: $(basename "$0") CHANGELOG_MESSAGE" 2>&1
+    echo 'Add the given message to the changelog and cut a release'
+    echo "Example: $(basename "$0") \"Bump unstructured to x.y.z\""
+}
+
+# Found at https://www.henryschmale.org/2019/04/30/incr-semver.html
+# $1 - semver string
+# $2 - level to incr {dev,release,minor,major} - release by default
+function incr_semver() {
+    IFS='.' read -ra ver <<< "$1"
+    [[ "${#ver[@]}" -ne 3 ]] && echo "Invalid semver string" && return 1
+    [[ "$#" -eq 1 ]] && level='release' || level=$2
+
+    release=${ver[2]}
+    minor=${ver[1]}
+    major=${ver[0]}
+
+    case $level in
+        # Drop the dev tag
+        dev)
+            release=$(echo "$release" | awk -F '-' '{print $1}')
+        ;;
+        release)
+            release=$((release+1))
+        ;;
+        minor)
+            release=0
+            minor=$((minor+1))
+        ;;
+        major)
+            release=0
+            minor=0
+            major=$((major+1))
+        ;;
+        *)
+            echo "Invalid level passed"
+            return 2
+    esac
+    echo "$major.$minor.$release"
+}
+
+
+if [[ -z "$1" ]]; then
+    usage
+    exit 0
+fi
+
+changelog_text="* $1"
+current_version=$(head -1 CHANGELOG.md | awk -F' ' '{print $2}')
+
+# If dev version, add to current change list and cut the release
+if [[ $current_version == *"dev"* ]]; then
+    new_version=$(incr_semver "$current_version" dev)
+
+    # Replace the version (drop the dev tag)
+    sed -i 's/'"$current_version"'/'"$new_version"'/' CHANGELOG.md
+
+    # Find the first bullet, add the new change above it
+    sed -i '0,/^*/{s/\(^*.*\)/'"$changelog_text"'\n\1/}' CHANGELOG.md
+
+# If not dev version, create a new release
+else
+    new_version=$(incr_semver "$current_version" release)
+
+    cat <<EOF | cat - CHANGELOG.md > CHANGELOG.tmp
+## $new_version
+
+$changelog_text
+
+EOF
+
+  mv CHANGELOG.{tmp,md}
+
+fi


### PR DESCRIPTION
- Set dependabot to run daily and only pick up unstructured changes
- Add `version-increment.sh` to add a line to the changelog and cut a release
- Add a new action, triggered off dependabot prs, to run version-increment on pr branch

I may have the syntax a bit off, so we'll see what happens when dependabot runs next.