### PR TITLE
chore: use correct python version when running pip-compile in workflow

### DIFF
--- a/.github/workflows/bump_libraries.yaml
+++ b/.github/workflows/bump_libraries.yaml
@@ -8,6 +8,9 @@ on:
     paths:
       - 'requirements/**'
 
+env:
+  PYTHON_VERSION: "3.10"
+
 jobs:
     bump-changelog:
         runs-on: ubuntu-latest
@@ -16,6 +19,10 @@ jobs:
           contents: write 
         steps:
         - uses: actions/checkout@v4
+        - name: Set up Python ${{ env.PYTHON_VERSION }}
+          uses: actions/setup-python@v4
+          with:
+            python-version: ${{ env.PYTHON_VERSION }}
         - name: Dependabot metadata
           id: metadata
           uses: dependabot/fetch-metadata@v1

--- a/.github/workflows/bump_libraries.yaml
+++ b/.github/workflows/bump_libraries.yaml
@@ -9,7 +9,7 @@ on:
       - 'requirements/**'
 
 env:
-  PYTHON_VERSION: "3.10"
+  PYTHON_VERSION: "3.8"
 
 jobs:
     bump-changelog:


### PR DESCRIPTION
The default env will produce a different set of packages when the gh action does `make pip-compile`.