### PR TITLE
chore: do not log stack traces for HttpException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * Bump unstructured to 0.10.14
 * Improve parallel mode retry handling
-* Ensure that error handlers are logging the right thing
+* Improve logging during error handling. We don't need to log stack traces for expected errors.
 
 ## 0.0.43
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-## 0.0.44-dev1
+## 0.0.44
 
 * Bump unstructured to 0.10.14
 * Improve parallel mode retry handling
+* Ensure that error handlers are logging the right thing
 
 ## 0.0.43
 


### PR DESCRIPTION
This improves on https://github.com/Unstructured-IO/unstructured-api/pull/224. My first attempt dumps the stack for any HttpException, which means any explicit 400, etc, that we raise. What we really want is the stack trace for unexpected errors, that is, anything that isn't HttpException.

* Move the stack dump to the base Exception handler
* Log `e.detail` in the HttpException handler. This is also important - we want to see what the user ran into.
* Disable the `uvicorn.error` logger, which also dumps stack on any exception. We want that to go through our handler.

To test, use the curl commands from the last pr.

The HttpException (filetype not supported error) should cleanly show as a one liner:
```
2023-09-15 12:06:13,570 unstructured_api ERROR Unable to process logger_config.yaml: File type None is not supported.
2023-09-15 12:06:13,570 127.0.0.1:58003 POST /general/v0/general HTTP/1.1 - 400 Bad Request
```

The 500 error should show this one liner along with *a single* instance of the stack:
```
  File "/Users/austin/repos/pipeline-api/prepline_general/api/general.py", line 386, in pipeline_api
    raise e
  File "/Users/austin/repos/pipeline-api/prepline_general/api/general.py", line 367, in pipeline_api
    elements = partition(
  File "/Users/austin/.pyenv/versions/pipeline-api/lib/python3.10/site-packages/unstructured/partition/auto.py", line 348, in partition
    raise ValueError(
ValueError: Detected a JSON file that does not conform to the Unstructured schema. partition_json currently only processes serialized Unstructured output.

2023-09-15 12:00:09,585 unstructured_api ERROR Detected a JSON file that does not conform to the Unstructured schema. partition_json currently only processes serialized Unstructured output.
2023-09-15 12:00:09,585 127.0.0.1:57735 POST /general/v0/general HTTP/1.1 - 500 Internal Server Error
```