### PR TITLE
feat: add chunking_strategy kwarg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.47
+
+* **Adds `chunking_strategy` kwarg and associated params** These params allow users to "chunk" elements into larger or smaller `CompositeElement`s
+
 ## 0.0.46
 
 * Bump unstructured to 0.10.16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.0.47
+## 0.0.47-dev0
 
 * **Adds `chunking_strategy` kwarg and associated params** These params allow users to "chunk" elements into larger or smaller `CompositeElement`s
 

--- a/README.md
+++ b/README.md
@@ -192,13 +192,13 @@ curl -X 'POST'
 
 Set the `chunking_strategy` to chunk text into larger or smaller elements. Defaults to `None` with optional arg of `by_title`.
   Additional Parameters:
-    `multipage_sections``
+    `multipage_sections`
       If True, sections can span multiple pages. Defaults to True.
-    `combine_under_n_chars``
+    `combine_under_n_chars`
       Combines elements (for example a series of titles) until a section
-      reaches a length of n characters.
-    `new_after_n_chars``
-      Cuts off new sections once they reach a length of n characters
+      reaches a length of n characters. Defaults to 500.
+    `new_after_n_chars`
+      Cuts off new sections once they reach a length of "n" characters. Defaults to 1500.
 
 ```
 curl -X 'POST' 

--- a/README.md
+++ b/README.md
@@ -187,6 +187,29 @@ curl -X 'POST'
  | jq -C . | less -R
 ```
 
+
+#### Chunking Elements
+
+Set the `chunking_strategy` to chunk text into larger or smaller elements. Defaults to `None` with optional arg of `by_title`.
+  Additional Parameters:
+    `multipage_sections``
+      If True, sections can span multiple pages. Defaults to True.
+    `combine_under_n_chars``
+      Combines elements (for example a series of titles) until a section
+      reaches a length of n characters.
+    `new_after_n_chars``
+      Cuts off new sections once they reach a length of n characters
+
+```
+curl -X 'POST' 
+ 'https://api.unstructured.io/general/v0/general' \
+ -H 'accept: application/json'  \
+ -H 'Content-Type: multipart/form-data' \
+ -F 'files=@sample-docs/layout-parser-paper-fast.pdf' \
+ -F 'chunking_strategy=by_title' \
+ | jq -C . | less -R
+```
+
 ## Developer Quick Start
 
 * Using `pyenv` to manage virtualenv's is recommended

--- a/prepline_general/api/general.py
+++ b/prepline_general/api/general.py
@@ -550,7 +550,7 @@ def ungz_file(file: UploadFile, gz_uncompressed_content_type=None) -> UploadFile
 
 
 @router.post("/general/v0/general")
-@router.post("/general/v0.0.46/general")
+@router.post("/general/v0.0.47/general")
 def pipeline_1(
     request: Request,
     gz_uncompressed_content_type: Optional[str] = Form(default=None),

--- a/prepline_general/api/general.py
+++ b/prepline_general/api/general.py
@@ -220,6 +220,9 @@ def pipeline_api(
     m_strategy=[],
     m_xml_keep_tags=[],
     m_chunking_strategy=[],
+    m_multipage_sections=[],
+    m_combine_under_n_chars=[],
+    m_new_after_n_chars=[],
 ):
     if filename.endswith(".msg"):
         # Note(yuming): convert file type for msg files
@@ -247,6 +250,9 @@ def pipeline_api(
                         "m_strategy": m_strategy,
                         "m_xml_keep_tags": m_xml_keep_tags,
                         "m_chunking_strategy": m_chunking_strategy,
+                        "m_multipage_sections": m_multipage_sections,
+                        "m_combine_under_n_chars": m_combine_under_n_chars,
+                        "new_after_n_chars": m_new_after_n_chars,
                     },
                     default=str,
                 )
@@ -329,6 +335,13 @@ def pipeline_api(
         raise HTTPException(
             status_code=400, detail=f"Invalid chunking strategy: {chunking_strategy}. Must be one of {chunk_strategies}"
         )
+    
+    multipage_sections_str = (m_multipage_sections[0] if len(m_multipage_sections) else "false").lower()
+    multipage_sections = multipage_sections_str == "true"
+
+    combine_under_n_chars = (int(m_combine_under_n_chars[0]) if m_combine_under_n_chars and m_combine_under_n_chars[0].isdigit() else 500)
+
+    new_after_n_chars = (int(m_new_after_n_chars[0]) if m_new_after_n_chars and m_new_after_n_chars[0].isdigit() else 1500)
 
     try:
         logger.debug(
@@ -346,6 +359,9 @@ def pipeline_api(
                         "xml_keep_tags": xml_keep_tags,
                         "skip_infer_table_types": skip_infer_table_types,
                         "chunking_strategy": chunking_strategy,
+                        "multipage_sections": multipage_sections,
+                        "combine_under_n_chars": combine_under_n_chars,
+                        "new_after_n_chars": new_after_n_chars,
                     },
                     default=str,
                 )
@@ -373,6 +389,9 @@ def pipeline_api(
                 strategy=strategy,
                 xml_keep_tags=xml_keep_tags,
                 chunking_strategy=chunking_strategy,
+                multipage_sections=multipage_sections,
+                combine_under_n_chars=combine_under_n_chars,
+                new_after_n_chars=new_after_n_chars,
             )
         else:
             elements = partition(
@@ -389,6 +408,9 @@ def pipeline_api(
                 strategy=strategy,
                 xml_keep_tags=xml_keep_tags,
                 chunking_strategy=chunking_strategy,
+                multipage_sections=multipage_sections,
+                combine_under_n_chars=combine_under_n_chars,
+                new_after_n_chars=new_after_n_chars,
             )
     except ValueError as e:
         if "Invalid file" in e.args[0]:
@@ -544,6 +566,9 @@ def pipeline_1(
     strategy: List[str] = Form(default=[]),
     xml_keep_tags: List[str] = Form(default=[]),
     chunking_strategy: List[str] = Form(default=[]),
+    multipage_sections: List[str] = Form(default=[]),
+    combine_under_n_chars: List[str] = Form(default=[]),
+    new_after_n_chars: List[str] = Form(default=[]),
 ):
     if files:
         for file_index in range(len(files)):
@@ -596,6 +621,9 @@ def pipeline_1(
                     filename=file.filename,
                     file_content_type=file_content_type,
                     m_chunking_strategy=chunking_strategy,
+                    m_multipage_sections=multipage_sections,
+                    m_combine_under_n_chars=combine_under_n_chars,
+                    m_new_after_n_chars=new_after_n_chars,
                 )
 
                 if is_expected_response_type(media_type, type(response)):

--- a/preprocessing-pipeline-family.yaml
+++ b/preprocessing-pipeline-family.yaml
@@ -1,2 +1,2 @@
 name: general
-version: 0.0.46
+version: 0.0.47

--- a/test_general/api/test_app.py
+++ b/test_general/api/test_app.py
@@ -602,7 +602,7 @@ def test_chunking_strategy_param():
     )
     assert response.status_code == 200
     response_without_chunking = response.json()
-    
+
     # chunking
     response = client.post(
         MAIN_API_ROUTE,
@@ -613,4 +613,4 @@ def test_chunking_strategy_param():
 
     response_with_chunking = response.json()
     assert len(response_with_chunking) != len(response_without_chunking)
-    assert 'CompositeElement' in [element.get('type') for element in response_with_chunking]
+    assert "CompositeElement" in [element.get("type") for element in response_with_chunking]

--- a/test_general/api/test_app.py
+++ b/test_general/api/test_app.py
@@ -579,3 +579,29 @@ def test_password_protected_pdf():
     assert response.json() == {
         "detail": f"File: {str(test_file)} is encrypted. Please decrypt it with password."
     }
+
+
+def test_chunking_strategy_param():
+    """
+    Verify that responses do not chunk elements unless requested
+    """
+    client = TestClient(app)
+    test_file = Path("sample-docs") / "layout-parser-paper-fast.pdf"
+    response = client.post(
+        MAIN_API_ROUTE,
+        files=[("files", (str(test_file), open(test_file, "rb")))],
+        data={"strategy": "hi_res"},
+    )
+    assert response.status_code == 200
+    response_without_chunking = response.json()
+
+    response = client.post(
+        MAIN_API_ROUTE,
+        files=[("files", (str(test_file), open(test_file, "rb")))],
+        data={"chunking_strategy": "by_title"},
+    )
+    assert response.status_code == 200
+
+    # chunking_strategy 
+    response_with_chunking = response.json()[0]
+    assert len(response_with_chunking) != len(response_without_chunking)

--- a/test_general/api/test_app.py
+++ b/test_general/api/test_app.py
@@ -431,7 +431,7 @@ def test_parallel_mode_passes_params(monkeypatch):
             "strategy": "hi_res",
             "xml_keep_tags": True,
             "skip_infer_table_types": "foo",
-            "chunking_strategy": "foo",
+            "chunking_strategy": "by_title",
         },
     )
 
@@ -449,7 +449,7 @@ def test_parallel_mode_passes_params(monkeypatch):
         strategy="hi_res",
         xml_keep_tags=True,
         skip_infer_table_types="foo",
-        chunking_strategy="foo",
+        chunking_strategy="by_title",
     )
 
 

--- a/test_general/api/test_app.py
+++ b/test_general/api/test_app.py
@@ -622,7 +622,7 @@ def test_chunking_strategy_param():
     assert "CompositeElement" in [element.get("type") for element in response_with_chunking]
 
 
-def test_add_chunking_strategy_on_partition_auto_respects_multipage():
+def test_chunking_strategy_additional_params():
     client = TestClient(app)
     test_file = Path("sample-docs") / "layout-parser-paper-fast.pdf"
     response_from_multipage_false_combine_chars_0 = client.post(
@@ -654,9 +654,6 @@ def test_add_chunking_strategy_on_partition_auto_respects_multipage():
             "new_after_n_chars": "50000",
         },
     )
-    import pdb
-
-    pdb.set_trace()
     assert (
         response_multipage_true_combine_chars_5000.json()
         != response_from_multipage_true_combine_chars_0.json()

--- a/test_general/api/test_app.py
+++ b/test_general/api/test_app.py
@@ -431,6 +431,7 @@ def test_parallel_mode_passes_params(monkeypatch):
             "strategy": "hi_res",
             "xml_keep_tags": True,
             "skip_infer_table_types": "foo",
+            "chunking_strategy": "foo",
         },
     )
 
@@ -448,6 +449,7 @@ def test_parallel_mode_passes_params(monkeypatch):
         strategy="hi_res",
         xml_keep_tags=True,
         skip_infer_table_types="foo",
+        chunking_strategy="foo",
     )
 
 

--- a/test_general/api/test_app.py
+++ b/test_general/api/test_app.py
@@ -596,7 +596,8 @@ def test_chunking_strategy_param():
     )
     assert response.status_code == 200
     response_without_chunking = response.json()
-
+    
+    # chunking
     response = client.post(
         MAIN_API_ROUTE,
         files=[("files", (str(test_file), open(test_file, "rb")))],
@@ -604,6 +605,6 @@ def test_chunking_strategy_param():
     )
     assert response.status_code == 200
 
-    # chunking_strategy
-    response_with_chunking = response.json()[0]
+    response_with_chunking = response.json()
     assert len(response_with_chunking) != len(response_without_chunking)
+    assert 'CompositeElement' in [element.get('type') for element in response_with_chunking]

--- a/test_general/api/test_app.py
+++ b/test_general/api/test_app.py
@@ -602,6 +602,6 @@ def test_chunking_strategy_param():
     )
     assert response.status_code == 200
 
-    # chunking_strategy 
+    # chunking_strategy
     response_with_chunking = response.json()[0]
     assert len(response_with_chunking) != len(response_without_chunking)


### PR DESCRIPTION
Add `chunking_strategy` as a kwarg for parsing and associated test.

### Testing
```
curl -X 'POST' 'http://127.0.0.1:8000/general/v0/general' \
 -H 'accept: application/json'  \
 -H 'Content-Type: multipart/form-data' \
 -F 'files=@sample-docs/layout-parser-paper-fast.pdf' \
 -F 'chunking_strategy=by_title' \
 | jq -C . | less -R
```