### PR TITLE
feat: add `languages` kwarg

### DIFF
--- a/prepline_general/api/general.py
+++ b/prepline_general/api/general.py
@@ -219,6 +219,7 @@ def pipeline_api(
     m_skip_infer_table_types=[],
     m_strategy=[],
     m_xml_keep_tags=[],
+    m_languages=["eng"],
 ):
     if filename.endswith(".msg"):
         # Note(yuming): convert file type for msg files
@@ -245,6 +246,7 @@ def pipeline_api(
                         "m_skip_infer_table_types": m_skip_infer_table_types,
                         "m_strategy": m_strategy,
                         "m_xml_keep_tags": m_xml_keep_tags,
+                        "m_languages": m_languages,
                     },
                     default=str,
                 )
@@ -297,7 +299,7 @@ def pipeline_api(
     enable_parallel_mode = os.environ.get("UNSTRUCTURED_PARALLEL_MODE_ENABLED", "false")
     pdf_parallel_mode_enabled = enable_parallel_mode == "true"
 
-    ocr_languages = ("+".join(m_ocr_languages) if len(m_ocr_languages) else "eng").lower()
+    ocr_languages = ("+".join(m_ocr_languages) if m_ocr_languages and len(m_ocr_languages) else None)
 
     include_page_breaks_str = (
         m_include_page_breaks[0] if len(m_include_page_breaks) else "false"
@@ -321,6 +323,8 @@ def pipeline_api(
         m_skip_infer_table_types[0] if len(m_skip_infer_table_types) else ["pdf", "jpg", "png"]
     )
 
+    languages = m_languages
+
     try:
         logger.debug(
             "partition input data: {}".format(
@@ -336,6 +340,7 @@ def pipeline_api(
                         "model_name": hi_res_model_name,
                         "xml_keep_tags": xml_keep_tags,
                         "skip_infer_table_types": skip_infer_table_types,
+                        "languages": languages,
                     },
                     default=str,
                 )
@@ -362,6 +367,7 @@ def pipeline_api(
                 skip_infer_table_types=skip_infer_table_types,
                 strategy=strategy,
                 xml_keep_tags=xml_keep_tags,
+                languages=languages,
             )
         else:
             elements = partition(
@@ -377,6 +383,7 @@ def pipeline_api(
                 skip_infer_table_types=skip_infer_table_types,
                 strategy=strategy,
                 xml_keep_tags=xml_keep_tags,
+                languages=languages,
             )
     except ValueError as e:
         if "Invalid file" in e.args[0]:
@@ -531,6 +538,7 @@ def pipeline_1(
     skip_infer_table_types: List[str] = Form(default=[]),
     strategy: List[str] = Form(default=[]),
     xml_keep_tags: List[str] = Form(default=[]),
+    languages: List[str] = ["eng"],
 ):
     if files:
         for file_index in range(len(files)):
@@ -582,6 +590,7 @@ def pipeline_1(
                     response_type=media_type,
                     filename=file.filename,
                     file_content_type=file_content_type,
+                    m_languages=languages,
                 )
 
                 if is_expected_response_type(media_type, type(response)):

--- a/test_general/api/test_app.py
+++ b/test_general/api/test_app.py
@@ -136,7 +136,7 @@ def test_metadata_fields_removed():
         assert "detection_class_prob" not in response_without_coords[i]["metadata"]
 
 
-def test_ocr_languages_param():
+def test_ocr_languages_param(): # will eventually be depricated
     """
     Verify that we get the corresponding languages from the response with ocr_languages
     """
@@ -151,6 +151,37 @@ def test_ocr_languages_param():
     assert response.status_code == 200
     elements = response.json()
     assert elements[3]["text"].startswith("안녕하세요, 저 희 는 YGEAS 그룹")
+
+
+def test_languages_param():
+    """
+    Verify that we get the corresponding languages from the response with `languages`
+    """
+    client = TestClient(app)
+    test_file = Path("sample-docs") / "english-and-korean.png"
+    response = client.post(
+        MAIN_API_ROUTE,
+        files=[("files", (str(test_file), open(test_file, "rb")))],
+        data={"strategy": "ocr_only", "languages": ["eng", "kor"]},
+    )
+
+    assert response.status_code == 200
+    elements = response.json()
+    assert elements[3]["text"].startswith("안녕하세요, 저 희 는 YGEAS 그룹")
+
+
+def test_languages_and_ocr_languages_raises_error():
+    """
+    Verify that we get the corresponding languages from the response with `languages`
+    """
+    with pytest.raises(ValueError):
+        client = TestClient(app)
+        test_file = Path("sample-docs") / "english-and-korean.png"
+        client.post(
+            MAIN_API_ROUTE,
+            files=[("files", (str(test_file), open(test_file, "rb")))],
+            data={"strategy": "ocr_only", "languages": ["eng", "kor"], "ocr_languages": ["eng", "kor"]},
+        )
 
 
 def test_skip_infer_table_types_param():
@@ -376,7 +407,7 @@ def test_general_api_returns_400_bad_pdf():
     tmp.close()
 
 
-def test_general_api_returns_503(monkeypatch, mocker):
+def test_general_api_returns_503(monkeypatch):
     """
     When available memory is below the minimum. return a 503, unless our origin ip is 10.{4,5}.x.x
     """
@@ -432,7 +463,8 @@ def test_parallel_mode_passes_params(monkeypatch):
             "encoding": "foo",
             "hi_res_model_name": "yolox",
             "include_page_breaks": True,
-            "ocr_languages": "foo",
+            # "ocr_languages": "foo",
+            "languages": "foo",
             "pdf_infer_table_structure": True,
             "strategy": "hi_res",
             "xml_keep_tags": True,
@@ -449,7 +481,8 @@ def test_parallel_mode_passes_params(monkeypatch):
         model_name="yolox",
         encoding="foo",
         include_page_breaks=True,
-        ocr_languages="foo",
+        ocr_languages=None,
+        languages=["foo"],
         pdf_infer_table_structure=True,
         strategy="hi_res",
         xml_keep_tags=True,


### PR DESCRIPTION
Add `languages` as a kwarg for parsing and its associated tests

### Testing
```
curl -X 'POST' 'http://127.0.0.1:8000/general/v0/general' \
 -H 'accept: application/json'  \
 -H 'Content-Type: multipart/form-data' \
 -F 'files=@sample-docs/english-and-korean.png' \
-F 'languages=eng'  \
-F 'languages=kor'  \
 | jq -C . | less -R
```