### PR TITLE
fix: Do not return 400 error for encrypted but readable pdfs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 0.0.47-dev0
+## 0.0.47
 
 * **Adds `chunking_strategy` kwarg and associated params** These params allow users to "chunk" elements into larger or smaller `CompositeElement`s
+* Fix some pdfs incorrectly returning a file is encrypted error
 
 ## 0.0.46
 

--- a/prepline_general/api/general.py
+++ b/prepline_general/api/general.py
@@ -473,7 +473,6 @@ def get_validated_mimetype(file):
             raise HTTPException(
                 status_code=400,
                 detail=(
-                    f"Unable to process {file.filename}: "
                     f"File type {content_type} is not supported."
                 ),
             )

--- a/prepline_general/api/general.py
+++ b/prepline_general/api/general.py
@@ -273,14 +273,17 @@ def pipeline_api(
     if file_content_type == "application/pdf":
         try:
             pdf = PdfReader(file)
+
+            # This will raise if the file is encrypted
+            pdf.metadata
         except pypdf.errors.EmptyFileError:
             raise HTTPException(
-                status_code=400, detail=f"{filename} does not appear to be a valid PDF"
+                status_code=400, detail=f"File does not appear to be a valid PDF"
             )
-        if pdf.is_encrypted:
+        except pypdf.errors.FileNotDecryptedError:
             raise HTTPException(
                 status_code=400,
-                detail=f"File: {filename} is encrypted. Please decrypt it with password.",
+                detail=f"File is encrypted. Please decrypt it with password.",
             )
 
     strategy = (m_strategy[0] if len(m_strategy) else "auto").lower()

--- a/test_general/api/test_app.py
+++ b/test_general/api/test_app.py
@@ -656,31 +656,31 @@ def test_encrypted_pdf():
     client = TestClient(app)
     test_file = Path("sample-docs") / "layout-parser-paper-fast.pdf"
     original_pdf = PdfReader(test_file)
-    temp_file = tempfile.NamedTemporaryFile()
 
-    # This file is user encrypted and cannot be read
-    writer = PdfWriter()
-    writer.append_pages_from_reader(original_pdf)
-    writer.encrypt(user_password="password123")
-    writer.write(temp_file.name)
+    with tempfile.NamedTemporaryFile() as temp_file:
+        # This file is user encrypted and cannot be read
+        writer = PdfWriter()
+        writer.append_pages_from_reader(original_pdf)
+        writer.encrypt(user_password="password123")
+        writer.write(temp_file.name)
 
-    # Response should be 400
-    response = client.post(
-        MAIN_API_ROUTE,
-        files=[("files", (str(temp_file.name), open(temp_file.name, "rb"), "application/pdf"))],
-    )
-    assert response.json() == {"detail": "File is encrypted. Please decrypt it with password."}
-    assert response.status_code == 400
+        # Response should be 400
+        response = client.post(
+            MAIN_API_ROUTE,
+            files=[("files", (str(temp_file.name), open(temp_file.name, "rb"), "application/pdf"))],
+        )
+        assert response.json() == {"detail": "File is encrypted. Please decrypt it with password."}
+        assert response.status_code == 400
 
-    # This file is owner encrypted, i.e. readable with edit restrictions
-    writer = PdfWriter()
-    writer.append_pages_from_reader(original_pdf)
-    writer.encrypt(user_password="", owner_password="password123", permissions_flag=0b1100)
-    writer.write(temp_file.name)
+        # This file is owner encrypted, i.e. readable with edit restrictions
+        writer = PdfWriter()
+        writer.append_pages_from_reader(original_pdf)
+        writer.encrypt(user_password="", owner_password="password123", permissions_flag=0b1100)
+        writer.write(temp_file.name)
 
-    # Response should be 200
-    response = client.post(
-        MAIN_API_ROUTE,
-        files=[("files", (str(temp_file.name), open(temp_file.name, "rb"), "application/pdf"))],
-    )
-    assert response.status_code == 200
+        # Response should be 200
+        response = client.post(
+            MAIN_API_ROUTE,
+            files=[("files", (str(temp_file.name), open(temp_file.name, "rb"), "application/pdf"))],
+        )
+        assert response.status_code == 200

--- a/test_general/api/test_app.py
+++ b/test_general/api/test_app.py
@@ -356,9 +356,7 @@ def test_general_api_returns_400_unsupported_file(example_filename):
     response = client.post(
         MAIN_API_ROUTE, files=[("files", (str(test_file), open(test_file, "rb"), filetype))]
     )
-    assert response.json() == {
-        "detail": f"Unable to process {str(test_file)}: " f"File type {filetype} is not supported."
-    }
+    assert response.json() == {"detail": f"File type {filetype} is not supported."}
     assert response.status_code == 400
 
 

--- a/test_general/api/test_app.py
+++ b/test_general/api/test_app.py
@@ -372,7 +372,7 @@ def test_general_api_returns_400_bad_pdf():
     response = client.post(
         MAIN_API_ROUTE, files=[("files", (str(tmp.name), open(tmp.name, "rb"), "application/pdf"))]
     )
-    assert response.json() == {"detail": f"{tmp.name} does not appear to be a valid PDF"}
+    assert response.json() == {"detail": "File does not appear to be a valid PDF"}
     assert response.status_code == 400
     tmp.close()
 
@@ -575,25 +575,6 @@ def test_partition_file_via_api_not_retryable_error_code(monkeypatch, mocker):
     # So we can't assert called_once, but we can assert the count is less than it
     # would have been if we used all retries.
     assert remote_partition.call_count < 4
-
-
-def test_password_protected_pdf():
-    """
-    Verify we get a 400 error if the PDF is password protected
-    """
-    client = TestClient(app)
-    # a password protected pdf file, password is "password"
-    test_file = Path("sample-docs") / "layout-parser-paper-password-protected.pdf"
-
-    response = client.post(
-        MAIN_API_ROUTE,
-        files=[("files", (str(test_file), open(test_file, "rb")))],
-        data={"strategy": "fast"},
-    )
-    assert response.status_code == 400
-    assert response.json() == {
-        "detail": f"File: {str(test_file)} is encrypted. Please decrypt it with password."
-    }
 
 
 def test_chunking_strategy_param():

--- a/test_general/api/test_app.py
+++ b/test_general/api/test_app.py
@@ -6,7 +6,6 @@ import requests
 import pandas as pd
 from fastapi.testclient import TestClient
 from fastapi import HTTPException
-import pypdf
 from pypdf import PdfWriter, PdfReader
 from unittest.mock import Mock, ANY
 


### PR DESCRIPTION
Fixes #236 

The `pdf.is_encrypted` check is true for files with edit protections, so we were returning 400 "This file is encrypted" for files that were perfectly readable. To verify, run this branch with `make run-web-app` and submit the pdf in the linked issue.

Other changes:
* Remove filename from some error messages. This can get way too verbose.