### PR TITLE
fix: remove `parent_id` until backwards compat bug is addressed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 0.0.47-dev0
+## 0.0.47
 
 * **Adds `chunking_strategy` kwarg and associated params** These params allow users to "chunk" elements into larger or smaller `CompositeElement`s
+* **Remove `parent_id` from the element metadata**. New metadata fields are causing errors with existing installs. We'll readd this once a fix is widely available.
 
 ## 0.0.46
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.0.47
+## 0.0.47-dev1
 
 * **Adds `chunking_strategy` kwarg and associated params** These params allow users to "chunk" elements into larger or smaller `CompositeElement`s
 * **Remove `parent_id` from the element metadata**. New metadata fields are causing errors with existing installs. We'll readd this once a fix is widely available.

--- a/prepline_general/api/general.py
+++ b/prepline_general/api/general.py
@@ -436,6 +436,11 @@ def pipeline_api(
         if element.metadata.detection_class_prob:
             elements[i].metadata.detection_class_prob = None
 
+        # Remove this until new md fields aren't breaking users
+        # See https://github.com/Unstructured-IO/unstructured/pull/1526
+        if element.metadata.parent_id:
+            elements[i].metadata.parent_id = None
+
     if response_type == "text/csv":
         df = convert_to_dataframe(elements)
         return df.to_csv(index=False)


### PR DESCRIPTION
Original issue: https://github.com/Unstructured-IO/unstructured-api/issues/237
Core library fix: https://github.com/Unstructured-IO/unstructured/pull/1526

Anyone who calls `partition_via_api` will hit this bug until they upgrade `unstructured`, which includes any Langchain users of `UnstructuredAPIFileLoader`. The immediate fix is to remove `parent_id` from the hosted api. Next, we can ensure that [langchain users](https://github.com/langchain-ai/langchain/pull/11025) are up to date. Finally, the core library fix above will address any new fields going forward. It will be safe to readd the `parent_id` once users are generally on `unstructured>=0.10.15`.