### PR TITLE
chore: start using the FastAPI version and other cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 0.0.48-dev0
+## 0.0.48
 
-* **Adds `languages` kwarg** `ocr_languages` will eventually be depricated and replaced by `lanugages` to specify what languages to use for OCR 
+* **Adds `languages` kwarg** `ocr_languages` will eventually be deprecated and replaced by `lanugages` to specify what languages to use for OCR 
+* Adds a startup log and other minor cleanups
 
 ## 0.0.47
 

--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ check-version:
 	scripts/version-sync.sh -c \
 		-s CHANGELOG.md \
 		-f preprocessing-pipeline-family.yaml release \
-		-f ${PACKAGE_NAME}/api/general.py release
+		-f ${PACKAGE_NAME}/api/app.py release
 
 ## version-sync:                update references to version with most recent version from CHANGELOG.md
 .PHONY: version-sync
@@ -138,4 +138,4 @@ version-sync:
 	scripts/version-sync.sh \
 		-s CHANGELOG.md \
 		-f preprocessing-pipeline-family.yaml release \
-		-f ${PACKAGE_NAME}/api/general.py release
+		-f ${PACKAGE_NAME}/api/app.py release

--- a/prepline_general/api/app.py
+++ b/prepline_general/api/app.py
@@ -1,9 +1,7 @@
 from fastapi import FastAPI, Request, status, HTTPException
 from fastapi.responses import JSONResponse
-import json
 import logging
 import os
-import traceback
 
 from .general import router as general_router
 
@@ -13,7 +11,7 @@ logger = logging.getLogger("unstructured_api")
 app = FastAPI(
     title="Unstructured Pipeline API",
     description="""""",
-    version="1.0.0",
+    version="0.0.48",
     docs_url="/general/docs",
     openapi_url="/general/openapi.json",
 )
@@ -28,26 +26,13 @@ uvicorn_logger.disabled = True
 @app.exception_handler(HTTPException)
 async def http_error_handler(request: Request, e: HTTPException):
     logger.error(e.detail)
-
     return JSONResponse(status_code=e.status_code, content={"detail": e.detail})
 
 
-# Note(austin) - Convert any other errors to HTTPException
-# to be handled above, and log the stack trace
+# Catch any other errors and return as 500
 @app.exception_handler(Exception)
 async def error_handler(request: Request, e: Exception):
-    trace = traceback.format_exc()
-
-    # Note(austin) - If ENV is set, dump the stack in json
-    # for nicer parsing. Soon we'll just have a json logger do this.
-    if os.environ.get("ENV") in ["dev", "prod"]:
-        trace = json.dumps(trace)
-
-    logger.error(trace)
-
-    error = HTTPException(status_code=500, detail=str(e))
-
-    return await http_error_handler(request, error)
+    return JSONResponse(status_code=500, content={"detail": str(e)})
 
 
 allowed_origins = os.environ.get("ALLOWED_ORIGINS", None)
@@ -83,3 +68,6 @@ logging.getLogger("uvicorn.access").addFilter(MetricsCheckFilter())
 @app.get("/healthcheck", status_code=status.HTTP_200_OK, include_in_schema=False)
 def healthcheck(request: Request):
     return {"healthcheck": "HEALTHCHECK STATUS: EVERYTHING OK!"}
+
+
+logger.info("Started Unstructured API")

--- a/prepline_general/api/general.py
+++ b/prepline_general/api/general.py
@@ -569,7 +569,7 @@ def ungz_file(file: UploadFile, gz_uncompressed_content_type=None) -> UploadFile
 
 
 @router.post("/general/v0/general")
-@router.post("/general/v0.0.48/general")
+@router.post(f"/general/v{app.version}/general")
 def pipeline_1(
     request: Request,
     gz_uncompressed_content_type: Optional[str] = Form(default=None),


### PR DESCRIPTION
* Set the current version in the FastAPI constructor and use `app.version` elsewhere
* Update version-sync commands accordingly
* Do not dump stack traces for unhandled errors
* Add a startup log, other startup is silent without `uvicorn.error`