### PR TITLE
chore: don't let dependabot pull unstructured-inference

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
       interval: "daily"
     # Only use this to bump our libraries
     allow:
-      - dependency-name: "unstructured*"
+      - dependency-name: "unstructured[local-inference]"
 
   - package-ecosystem: "github-actions"
     # NOTE(robinson) - Workflow files stored in the

--- a/.github/workflows/bump_libraries.yaml
+++ b/.github/workflows/bump_libraries.yaml
@@ -32,7 +32,10 @@ jobs:
           run: |
             pip install pip-tools
             make pip-compile
-            changelog_message="Bump ${{ steps.metadata.outputs.dependency-names }} to ${{ steps.metadata.outputs.new-version }}"
+            package=${{ steps.metadata.outputs.dependency-names }}
+            # Strip any [extras] from name
+            package=${package%\[*}
+            changelog_message="Bump $package to ${{ steps.metadata.outputs.new-version }}"
             ./scripts/version-increment.sh "$changelog_message"
             make version-sync
         - uses: stefanzweifel/git-auto-commit-action@v4


### PR DESCRIPTION
Given this fix: https://github.com/Unstructured-IO/unstructured/pull/1474

We should get the correct inference whenever unstructured is bumped. We can't take these out of order. Also tweak the gh action to remove `[local-inference]` when `bumping unstructured` message is added.