### PR TITLE
fix: handle PdfStreamError

### DIFF
--- a/prepline_general/api/app.py
+++ b/prepline_general/api/app.py
@@ -17,9 +17,10 @@ app = FastAPI(
 )
 
 # Note(austin) - This logger just dumps exceptions
-# We'd rather handle those below
+# We'd rather handle those below, so disable this in deployments
 uvicorn_logger = logging.getLogger("uvicorn.error")
-uvicorn_logger.disabled = True
+if os.environ.get("ENV") in ["dev", "prod"]:
+    uvicorn_logger.disabled = True
 
 
 # Catch all HTTPException for uniform logging and response

--- a/prepline_general/api/general.py
+++ b/prepline_general/api/general.py
@@ -278,13 +278,16 @@ def pipeline_api(
 
             # This will raise if the file is encrypted
             pdf.metadata
-        except pypdf.errors.EmptyFileError:
+        except (pypdf.errors.EmptyFileError, pypdf.errors.PdfStreamError):
             raise HTTPException(status_code=400, detail="File does not appear to be a valid PDF")
         except pypdf.errors.FileNotDecryptedError:
             raise HTTPException(
                 status_code=400,
                 detail="File is encrypted. Please decrypt it with password.",
             )
+        except Exception as e:
+            logger.warn(f"PDF read error: {e}")
+            raise HTTPException(status_code=400, detail="File does not appear to be a valid PDF")
 
     strategy = (m_strategy[0] if len(m_strategy) else "auto").lower()
     strategies = ["fast", "hi_res", "auto", "ocr_only"]

--- a/test_general/api/test_app.py
+++ b/test_general/api/test_app.py
@@ -409,6 +409,16 @@ def test_general_api_returns_400_bad_pdf():
     assert response.status_code == 400
     tmp.close()
 
+    # Don't blow up if this isn't actually a pdf
+    test_file = Path("sample-docs") / "fake-power-point.pptx"
+    response = client.post(
+        MAIN_API_ROUTE,
+        files=[("files", (str(test_file), open(test_file, "rb"), "application/pdf"))],
+    )
+
+    assert response.json() == {"detail": "File does not appear to be a valid PDF"}
+    assert response.status_code == 400
+
 
 def test_general_api_returns_503(monkeypatch):
     """


### PR DESCRIPTION
Fixes #266 

We see this error when a user sends a non pdf file, and the content type is set to pdf. We try to load it in `PdfReader`, and see warnings like this:

```
WARNING:pypdf._reader:invalid pdf header: b'\xff\xd8\xff\xe1\x9b'
WARNING:pypdf._reader:EOF marker not found
```

We just need to catch this error and return a useful 400 message. Also, add a general catch to log any other pdf read errors here - we've hit a few others.

To verify, send any non pdf file with content type as pdf:
```python
import requests

filename = "/path/to/jpeg/file"

res = requests.post(
    "http://localhost:8000/general/v0/general",
    files={"files": (filename, open(filename, "rb"), "application/pdf")},
    )

print(res.text)
```

Other changes:
* Do not remove `uvicorn.error` logs locally, these can be useful