### PR TITLE
Remove filenames from BadZipFile error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.53-dev0
+
+* Simplify the error message for BadZipFile errors
+
 ## 0.0.52
 
 * Bump unstructured to 0.10.21

--- a/prepline_general/api/app.py
+++ b/prepline_general/api/app.py
@@ -11,7 +11,7 @@ logger = logging.getLogger("unstructured_api")
 app = FastAPI(
     title="Unstructured Pipeline API",
     description="""""",
-    version="0.0.52",
+    version="0.0.53",
     docs_url="/general/docs",
     openapi_url="/general/openapi.json",
 )

--- a/prepline_general/api/general.py
+++ b/prepline_general/api/general.py
@@ -603,7 +603,7 @@ def ungz_file(file: UploadFile, gz_uncompressed_content_type=None) -> UploadFile
 
 
 @router.post("/general/v0/general")
-@router.post("/general/v0.0.52/general")
+@router.post("/general/v0.0.53/general")
 def pipeline_1(
     request: Request,
     gz_uncompressed_content_type: Optional[str] = Form(default=None),

--- a/prepline_general/api/general.py
+++ b/prepline_general/api/general.py
@@ -467,7 +467,7 @@ def pipeline_api(
         if "File is not a zip file" in e.args[0]:
             raise HTTPException(
                 status_code=400,
-                detail=f"{filename} is not a valid '{file_content_type}' content type",
+                detail="File is not a valid docx",
             )
 
     # Clean up returned elements

--- a/preprocessing-pipeline-family.yaml
+++ b/preprocessing-pipeline-family.yaml
@@ -1,2 +1,2 @@
 name: general
-version: 0.0.52
+version: 0.0.53

--- a/test_general/api/test_app.py
+++ b/test_general/api/test_app.py
@@ -759,7 +759,7 @@ def test_general_api_returns_400_bad_docx():
             )
         ],
     )
-    assert "txt is not a valid" in response.json().get("detail")
+    assert response.json().get("detail") == "File is not a valid docx"
     assert response.status_code == 400
 
 


### PR DESCRIPTION
In many cases these are tempfiles and just create additional noise.