### PR TITLE
chore: prefetch chipper in the api image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -67,12 +67,14 @@ jobs:
       run: |
         # Clear some space (https://github.com/actions/runner-images/issues/2840)
         sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/share/boost
+        echo ${{ secrets.HF_TOKEN }} >> hf_token
 
         ARCH=$(cut -d "/" -f2 <<< ${{ matrix.docker-platform }})
         DOCKER_BUILDKIT=1 docker buildx build --platform=$ARCH --load \
           --build-arg PIP_VERSION=$PIP_VERSION \
           --build-arg BUILDKIT_INLINE_CACHE=1 \
           --build-arg PIPELINE_PACKAGE=${{ env.PIPELINE_FAMILY }} \
+          --secret id=hf_token,src=hf_token \
           --provenance=false \
           --progress plain \
           --cache-from $DOCKER_BUILD_REPOSITORY:$ARCH \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-## 0.0.53-dev1
+## 0.0.53-dev2
 
 * Simplify the error message for BadZipFile errors
 * Bump unstructured to 0.10.22
+* Prefetch the Chipper model in the image when we have a token
 
 ## 0.0.52
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,6 @@ RUN --mount=type=secret,id=hf_token \
      export UNSTRUCTURED_HF_TOKEN=$(cat /run/secrets/hf_token) && \
     ./scripts/maybe-pull-chipper.sh
 
-
 USER ${NB_USER}
 
 FROM model-deps as code

--- a/scripts/app-start.sh
+++ b/scripts/app-start.sh
@@ -1,14 +1,5 @@
 #!/usr/bin/env bash
 
-UNSTRUCTURED_DOWNLOAD_CHIPPER=${UNSTRUCTURED_DOWNLOAD_CHIPPER:-"false"}
-
-if [[ "$(echo "${UNSTRUCTURED_DOWNLOAD_CHIPPER}" | tr '[:upper:]' '[:lower:]')" == "true" ]]; then
-  echo "warming chipper model"
-  # NOTE(crag): in the cloud, this could add a minute to startup time
-  UNSTRUCTURED_HI_RES_SUPPORTED_MODEL=chipper python3.8 -c \
-    "from unstructured.ingest.doc_processor.generalized import initialize; initialize()"
-fi
-
 uvicorn prepline_general.api.app:app \
 	--log-config logger_config.yaml \
         --host 0.0.0.0

--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -16,11 +16,17 @@ DOCKER_BUILD_CMD=(docker buildx build --load -f Dockerfile \
   --progress plain \
   --target code \
   --cache-from "$DOCKER_REPOSITORY":latest \
-  -t "$DOCKER_IMAGE" .)
+  -t "$DOCKER_IMAGE")
+
+# If a token is present to download Chipper, pass it in as a secret file
+if [ -f hf_token ]; then
+  # --secret id=hf_token,src=env_file \
+  DOCKER_BUILD_CMD+=("--secret" "id=hf_token,src=hf_token")
+fi
 
 # only build for specific platform if DOCKER_PLATFORM is set
 if [ -n "${DOCKER_PLATFORM:-}" ]; then
   DOCKER_BUILD_CMD+=("--platform=$DOCKER_PLATFORM")
 fi
 
-DOCKER_BUILDKIT=1 "${DOCKER_BUILD_CMD[@]}"
+DOCKER_BUILDKIT=1 "${DOCKER_BUILD_CMD[@]}" .

--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -20,7 +20,6 @@ DOCKER_BUILD_CMD=(docker buildx build --load -f Dockerfile \
 
 # If a token is present to download Chipper, pass it in as a secret file
 if [ -f hf_token ]; then
-  # --secret id=hf_token,src=env_file \
   DOCKER_BUILD_CMD+=("--secret" "id=hf_token,src=hf_token")
 fi
 

--- a/scripts/maybe-pull-chipper.sh
+++ b/scripts/maybe-pull-chipper.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+if [ -n "$UNSTRUCTURED_HF_TOKEN" ]; then
+    echo Preloading Chipper model...
+  UNSTRUCTURED_HI_RES_SUPPORTED_MODEL=chipper python3.10 -c \
+    "from unstructured.ingest.pipeline.initialize import initialize; initialize()"
+fi


### PR DESCRIPTION
Fetch Chipper at buildtime so we don't have to download it in the middle of a request. The new Chipper is in our private huggingface, so when the HF_TOKEN is present, pass it as a secret and set it in the env. A new script, `maybe-download-chipper.sh` runs during the build, and if the token is set, it will fetch the model.

Removes the preload chipper logic from start-app.sh.

Note this pr is against #285 for the new `unstructured`. Once that's merged, we can put this against main and the tests will pick it up.