### PR TITLE
fix: fix local variable 'elements' referenced before assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
-## 0.0.54-dev1
+## 0.0.54-dev2
 
 * Bump unstructured to 0.10.24
 * Use a generator when splitting pdfs in parallel mode
 * Add a default memory minimum for 503 check
+* Fix a UnboundLocalError when an invalid docx file is caught
 
 ## 0.0.53
 

--- a/prepline_general/api/general.py
+++ b/prepline_general/api/general.py
@@ -467,12 +467,11 @@ def pipeline_api(
                 detail="Json schema does not match the Unstructured schema",
             )
         raise e
-    except zipfile.BadZipFile as e:
-        if "File is not a zip file" in e.args[0]:
-            raise HTTPException(
-                status_code=400,
-                detail="File is not a valid docx",
-            )
+    except zipfile.BadZipFile:
+        raise HTTPException(
+            status_code=400,
+            detail="File is not a valid docx",
+        )
 
     # Clean up returned elements
     # Note(austin): pydantic should control this sort of thing for us


### PR DESCRIPTION
We've seen this error in the hosted api:

```
UnboundLocalError: local variable 'elements' referenced before assignment
File "prepline_general/api/general.py", line 649, in response_generator
    response = pipeline_api(
  File "prepline_general/api/general.py", line 464, in pipeline_api
    for i, element in enumerate(elements):
```

The if block in the check for `zipfile.BadZipFile` allows us to fall through without assigning `elements`. Instead, we should raise a 400 error when we catch this exception.