### PR TITLE
chore: disable Chipper in the API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.55-dev0
+
+* Temporary - disable Chipper in the API
+
 ## 0.0.54
 
 * Bump unstructured to 0.10.25

--- a/prepline_general/api/app.py
+++ b/prepline_general/api/app.py
@@ -11,7 +11,7 @@ logger = logging.getLogger("unstructured_api")
 app = FastAPI(
     title="Unstructured Pipeline API",
     description="""""",
-    version="0.0.54",
+    version="0.0.55",
     docs_url="/general/docs",
     openapi_url="/general/openapi.json",
 )

--- a/prepline_general/api/general.py
+++ b/prepline_general/api/general.py
@@ -318,6 +318,12 @@ def pipeline_api(
 
     hi_res_model_name = m_hi_res_model_name[0] if len(m_hi_res_model_name) else None
 
+    if hi_res_model_name and hi_res_model_name in CHIPPER_MODEL_TYPES:
+        raise HTTPException(
+            status_code=400,
+            detail="Chipper is not yet supported in the hosted API",
+        )
+
     if hi_res_model_name and hi_res_model_name in CHIPPER_MODEL_TYPES and show_coordinates:
         raise HTTPException(
             status_code=400,

--- a/prepline_general/api/general.py
+++ b/prepline_general/api/general.py
@@ -605,7 +605,7 @@ def ungz_file(file: UploadFile, gz_uncompressed_content_type=None) -> UploadFile
 
 
 @router.post("/general/v0/general")
-@router.post("/general/v0.0.54/general")
+@router.post("/general/v0.0.55/general")
 def pipeline_1(
     request: Request,
     gz_uncompressed_content_type: Optional[str] = Form(default=None),

--- a/preprocessing-pipeline-family.yaml
+++ b/preprocessing-pipeline-family.yaml
@@ -1,2 +1,2 @@
 name: general
-version: 0.0.54
+version: 0.0.55


### PR DESCRIPTION
This is for the very short term. Chipper requires a lot of resources that easily overwhelm the server. We need to disable Chipper while we update the hosted API, otherwise all users may experience 502 errors.

Verify by making a Chipper request - you'll see the following error message:
```
curl 'localhost:8000/general/v0/general' \
--header 'Accept: application/json' \
--form 'files=@"layout-parser-paper.pdf"' \
--form 'strategy="hi_res"'
--form 'hi_res_model_name="chipper"'

{
    "detail": "Chipper is not yet supported in the hosted API"
}
```