### PR TITLE
remove keyscan and ssh files as they are no longer needed.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,6 @@ ENV HOME /home/${NB_USER}
 RUN groupadd --gid ${NB_UID} ${NB_USER}
 RUN useradd --uid ${NB_UID} --gid ${NB_UID} ${NB_USER}
 WORKDIR ${HOME}
-RUN mkdir ${HOME}/.ssh && chmod go-rwx ${HOME}/.ssh \
-  &&  ssh-keyscan -t rsa github.com >> /home/${NB_USER}/.ssh/known_hosts
 
 ENV PYTHONPATH="${PYTHONPATH}:${HOME}"
 ENV PATH="/home/${NB_USER}/.local/bin:${PATH}"


### PR DESCRIPTION
The ssh keyscan and authorized_hosts file is no longer needed as private repos are not being cloned.  Removing this reduces false positives from scanners.