### PR TITLE
chore: reintroduce parent_id metadata field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.55-dev0
+
+* Bring parent_id metadata field back after fixing a backwards compatibility bug
+
 ## 0.0.54
 
 * Bump unstructured to 0.10.25

--- a/prepline_general/api/app.py
+++ b/prepline_general/api/app.py
@@ -11,7 +11,7 @@ logger = logging.getLogger("unstructured_api")
 app = FastAPI(
     title="Unstructured Pipeline API",
     description="""""",
-    version="0.0.54",
+    version="0.0.55",
     docs_url="/general/docs",
     openapi_url="/general/openapi.json",
 )

--- a/prepline_general/api/general.py
+++ b/prepline_general/api/general.py
@@ -594,7 +594,7 @@ def ungz_file(file: UploadFile, gz_uncompressed_content_type=None) -> UploadFile
 
 
 @router.post("/general/v0/general")
-@router.post("/general/v0.0.54/general")
+@router.post("/general/v0.0.55/general")
 def pipeline_1(
     request: Request,
     gz_uncompressed_content_type: Optional[str] = Form(default=None),

--- a/prepline_general/api/general.py
+++ b/prepline_general/api/general.py
@@ -483,11 +483,6 @@ def pipeline_api(
         if element.metadata.detection_class_prob:
             elements[i].metadata.detection_class_prob = None
 
-        # Remove this until new md fields aren't breaking users
-        # See https://github.com/Unstructured-IO/unstructured/pull/1526
-        if element.metadata.parent_id:
-            elements[i].metadata.parent_id = None
-
     if response_type == "text/csv":
         df = convert_to_dataframe(elements)
         return df.to_csv(index=False)

--- a/preprocessing-pipeline-family.yaml
+++ b/preprocessing-pipeline-family.yaml
@@ -1,2 +1,2 @@
 name: general
-version: 0.0.54
+version: 0.0.55


### PR DESCRIPTION
This was removed in #252 to address a backwards compat bug in Langchain. The bug was fixed in unstructured 0.10.15 and this is now the min version in Langchain.