### PR TITLE
chore: remap `chipper` to use `chipperv2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 0.0.56-dev1
+## 0.0.56
 * **Add `max_characters` param for chunking** This param gives users additional control to "chunk" elements into larger or smaller `CompositeElement`s
 * Bump unstructured to 0.10.28
+* Make sure chipperv2 is called whien `hi_res_model_name==chipper`
 
 
 ## 0.0.55

--- a/prepline_general/api/general.py
+++ b/prepline_general/api/general.py
@@ -346,6 +346,10 @@ def pipeline_api(
 
     hi_res_model_name = m_hi_res_model_name[0] if len(m_hi_res_model_name) else None
 
+    # Make sure chipper aliases to the latest model
+    if hi_res_model_name and hi_res_model_name == "chipper":
+        hi_res_model_name = "chipperv2"
+
     if hi_res_model_name and hi_res_model_name in CHIPPER_MODEL_TYPES and show_coordinates:
         raise HTTPException(
             status_code=400,
@@ -476,7 +480,10 @@ def pipeline_api(
             elements = partition(**partition_kwargs)
 
     except OSError as e:
-        if "chipper-fast-fine-tuning is not a local folder" in e.args[0]:
+        if (
+            "chipper-fast-fine-tuning is not a local folder" in e.args[0]
+            or "ved-fine-tuning is not a local folder" in e.args[0]
+        ):
             raise HTTPException(
                 status_code=400,
                 detail="The Chipper model is not available for download. It can be accessed via the official hosted API.",


### PR DESCRIPTION
We want this to alias to the current model. Also, wrap the error that comes from chipperv1 becoming a private model.

To verify:
* Run the server
```
make run-web-app
```
* A call to chipperv1 should give a useful error:
```
curl -X POST 'http://localhost:8000/general/v0/general' --form files="@$file" --form strategy=hi_res --form hi_res_model_name=chipperv1
{"detail":"The Chipper model is not available for download. It can be accessed via the official hosted API."}
```
* Change the model name to `chipper`. You should see `chipperv2` in the log message containing partition input data