### PR TITLE
catch 500 error for fast strategy

### DIFF
--- a/prepline_general/api/general.py
+++ b/prepline_general/api/general.py
@@ -446,12 +446,18 @@ def pipeline_api(
     except ValueError as e:
         if "Invalid file" in e.args[0]:
             raise HTTPException(
-                status_code=400, detail=f"{file_content_type} not currently supported"
+                status_code=400, 
+                detail=f"{file_content_type} not currently supported"
             )
         if "Unstructured schema" in e.args[0]:
             raise HTTPException(
                 status_code=400,
                 detail="Json schema does not match the Unstructured schema",
+            )
+        if "fast strategy is not available for image files" in e.args[0]:
+            raise HTTPException(
+                status_code=400, 
+                detail="The fast strategy is not available for image files",
             )
 
         raise e

--- a/prepline_general/api/general.py
+++ b/prepline_general/api/general.py
@@ -446,8 +446,7 @@ def pipeline_api(
     except ValueError as e:
         if "Invalid file" in e.args[0]:
             raise HTTPException(
-                status_code=400, 
-                detail=f"{file_content_type} not currently supported"
+                status_code=400, detail=f"{file_content_type} not currently supported"
             )
         if "Unstructured schema" in e.args[0]:
             raise HTTPException(
@@ -456,7 +455,7 @@ def pipeline_api(
             )
         if "fast strategy is not available for image files" in e.args[0]:
             raise HTTPException(
-                status_code=400, 
+                status_code=400,
                 detail="The fast strategy is not available for image files",
             )
 
@@ -503,7 +502,7 @@ def _check_free_memory():
         raise HTTPException(
             status_code=503, detail="Server is under heavy load. Please try again later."
         )
-    
+
 
 def _check_pdf(file):
     """Check if the PDF file is encrypted, otherwise assume it is not a valid PDF."""
@@ -538,7 +537,7 @@ def _validate_hi_res_model_name(m_hi_res_model_name, show_coordinates):
     # Make sure chipper aliases to the latest model
     if hi_res_model_name and hi_res_model_name == "chipper":
         hi_res_model_name = "chipperv2"
-    
+
     if hi_res_model_name and hi_res_model_name in CHIPPER_MODEL_TYPES and show_coordinates:
         raise HTTPException(
             status_code=400,

--- a/test_general/api/test_app.py
+++ b/test_general/api/test_app.py
@@ -813,3 +813,18 @@ def test_chipper_memory_protection(monkeypatch, mocker):
         # Assert only one call got through
         assert status_codes.count(200) == 1
         assert status_codes.count(503) == 2
+
+
+def test_invalid_strategy_for_image_file():
+    """
+    Verify that we get a 400 error if we use "strategy=fast" with an image file
+    """
+    client = TestClient(app)
+    test_file = Path("sample-docs") / "layout-parser-paper-fast.jpg"
+    resp = client.post(
+        MAIN_API_ROUTE,
+        files=[("files", (str(test_file), open(test_file, "rb")))],
+        data={"strategy": "fast"},
+    )
+    assert resp.status_code == 400
+    assert "fast strategy is not available for image files" in resp.text


### PR DESCRIPTION
Closes #314

We don't support any fallback for fast strategy on images anymore, and unst will raise [value error](https://github.com/Unstructured-IO/unstructured/blob/main/unstructured/partition/strategies.py#L22) if partition uses fast strategy for image files. This catches the error and raises a 400 HTTPException.

Also, this refactors `pipeline_api` to extract out some validation of arguments.