### PR TITLE
chore: add a log message when returning 503 due to low memory

### DIFF
--- a/prepline_general/api/general.py
+++ b/prepline_general/api/general.py
@@ -499,7 +499,7 @@ def _check_free_memory():
     memory_free_minimum = int(os.environ.get("UNSTRUCTURED_MEMORY_FREE_MINIMUM_MB", 2048))
 
     if mem.available <= memory_free_minimum * 1024 * 1024:
-        logger.warn(f"Rejecting because free memory is below {memory_free_minimum} MB")
+        logger.warning(f"Rejecting because free memory is below {memory_free_minimum} MB")
         raise HTTPException(
             status_code=503, detail="Server is under heavy load. Please try again later."
         )

--- a/prepline_general/api/general.py
+++ b/prepline_general/api/general.py
@@ -499,6 +499,7 @@ def _check_free_memory():
     memory_free_minimum = int(os.environ.get("UNSTRUCTURED_MEMORY_FREE_MINIMUM_MB", 2048))
 
     if mem.available <= memory_free_minimum * 1024 * 1024:
+        logger.warn(f"Rejecting because free memory is below {memory_free_minimum} MB")
         raise HTTPException(
             status_code=503, detail="Server is under heavy load. Please try again later."
         )


### PR DESCRIPTION
Clarify what's causing the error for the user. To test, set the free minimum really high and check that the log message shows.

```
export UNSTRUCTURED_MEMORY_FREE_MINIMUM_MB=16000
make run-web-app

file=sample-docs/layout-parser-paper.pdf
curl -X POST 'http://localhost:8000/general/v0/general' --form files="@$file"
```