### PR TITLE
fix: handle argument of type 'int' is not iterable

### DIFF
--- a/prepline_general/api/general.py
+++ b/prepline_general/api/general.py
@@ -433,16 +433,17 @@ def pipeline_api(
             elements = partition(**partition_kwargs)
 
     except OSError as e:
-        if (
-            "chipper-fast-fine-tuning is not a local folder" in e.args[0]
-            or "ved-fine-tuning is not a local folder" in e.args[0]
-        ):
+        if isinstance(e.args[0], str) and ("chipper-fast-fine-tuning is not a local folder" in e.args[0] or "ved-fine-tuning is not a local folder" in e.args[0]):
             raise HTTPException(
                 status_code=400,
                 detail="The Chipper model is not available for download. It can be accessed via the official hosted API.",
             )
 
-        raise e
+        # OSError isn't caught by our top level handler, so convert it here
+        raise HTTPException(
+            status_code=500,
+            detail=str(e),
+        )
     except ValueError as e:
         if "Invalid file" in e.args[0]:
             raise HTTPException(

--- a/prepline_general/api/general.py
+++ b/prepline_general/api/general.py
@@ -433,7 +433,10 @@ def pipeline_api(
             elements = partition(**partition_kwargs)
 
     except OSError as e:
-        if isinstance(e.args[0], str) and ("chipper-fast-fine-tuning is not a local folder" in e.args[0] or "ved-fine-tuning is not a local folder" in e.args[0]):
+        if isinstance(e.args[0], str) and (
+            "chipper-fast-fine-tuning is not a local folder" in e.args[0]
+            or "ved-fine-tuning is not a local folder" in e.args[0]
+        ):
             raise HTTPException(
                 status_code=400,
                 detail="The Chipper model is not available for download. It can be accessed via the official hosted API.",

--- a/test_general/api/test_app.py
+++ b/test_general/api/test_app.py
@@ -836,12 +836,14 @@ def test_invalid_strategy_for_image_file():
         (
             OSError("chipper-fast-fine-tuning is not a local folder"),
             400,
-            "The Chipper model is not available for download. It can be accessed via the official hosted API.",
+            "The Chipper model is not available for download. "
+            "It can be accessed via the official hosted API.",
         ),
         (
             OSError("ved-fine-tuning is not a local folder"),
             400,
-            "The Chipper model is not available for download. It can be accessed via the official hosted API.",
+            "The Chipper model is not available for download. "
+            "It can be accessed via the official hosted API.",
         ),
         (OSError(1, "An error happened"), 500, "[Errno 1] An error happened"),
     ],

--- a/test_general/api/test_app.py
+++ b/test_general/api/test_app.py
@@ -833,8 +833,16 @@ def test_invalid_strategy_for_image_file():
 @pytest.mark.parametrize(
     ("exception", "status_code", "message"),
     [
-        (OSError("chipper-fast-fine-tuning is not a local folder"), 400,  "The Chipper model is not available for download. It can be accessed via the official hosted API."),
-        (OSError("ved-fine-tuning is not a local folder"), 400,  "The Chipper model is not available for download. It can be accessed via the official hosted API."),
+        (
+            OSError("chipper-fast-fine-tuning is not a local folder"),
+            400,
+            "The Chipper model is not available for download. It can be accessed via the official hosted API.",
+        ),
+        (
+            OSError("ved-fine-tuning is not a local folder"),
+            400,
+            "The Chipper model is not available for download. It can be accessed via the official hosted API.",
+        ),
         (OSError(1, "An error happened"), 500, "[Errno 1] An error happened"),
     ],
 )
@@ -862,4 +870,4 @@ def test_chipper_not_available_errors(monkeypatch, mocker, exception, status_cod
     )
 
     assert resp.status_code == status_code
-    assert resp.json().get('detail') == message
+    assert resp.json().get("detail") == message


### PR DESCRIPTION
Closes #323 

Certain OSErrors come back with an errno in the first arg. We were searching for a substring in here, so we just need to skip the check if e.args[0] is not a string.

The new test case verifies this by raising an error with a errno.