### PR TITLE
feat: return 422 errors for unprocessable files

### DIFF
--- a/prepline_general/api/general.py
+++ b/prepline_general/api/general.py
@@ -466,7 +466,7 @@ def pipeline_api(
         raise e
     except zipfile.BadZipFile:
         raise HTTPException(
-            status_code=400,
+            status_code=422,
             detail="File is not a valid docx",
         )
 
@@ -523,7 +523,7 @@ def _check_pdf(file):
             detail="File is encrypted. Please decrypt it with password.",
         )
     except pypdf.errors.PdfReadError:
-        raise HTTPException(status_code=400, detail="File does not appear to be a valid PDF")
+        raise HTTPException(status_code=422, detail="File does not appear to be a valid PDF")
 
 
 def _validate_strategy(m_strategy):
@@ -807,7 +807,7 @@ def pipeline_1(
             )
     else:
         raise HTTPException(
-            detail='Request parameter "files" is required.\n',
+            detail='Request parameter "files" is required.',
             status_code=status.HTTP_400_BAD_REQUEST,
         )
 

--- a/test_general/api/test_app.py
+++ b/test_general/api/test_app.py
@@ -398,9 +398,9 @@ def test_general_api_returns_400_unsupported_file(example_filename):
     assert response.status_code == 400
 
 
-def test_general_api_returns_400_bad_pdf():
+def test_general_api_returns_422_bad_pdf():
     """
-    Verify that we get a 400 for invalid PDF files
+    Verify that we get a 422 for invalid PDF files
     """
     tmp = tempfile.NamedTemporaryFile(suffix=".pdf")
     tmp.write(b"This is not a valid PDF")
@@ -409,7 +409,7 @@ def test_general_api_returns_400_bad_pdf():
         MAIN_API_ROUTE, files=[("files", (str(tmp.name), open(tmp.name, "rb"), "application/pdf"))]
     )
     assert response.json() == {"detail": "File does not appear to be a valid PDF"}
-    assert response.status_code == 400
+    assert response.status_code == 422
     tmp.close()
 
     # Don't blow up if this isn't actually a pdf
@@ -757,7 +757,7 @@ def test_encrypted_pdf():
         assert response.status_code == 200
 
 
-def test_general_api_returns_400_bad_docx():
+def test_general_api_returns_422_bad_docx():
     """
     Verify that we get a 400 for invalid docx files
     """
@@ -777,7 +777,7 @@ def test_general_api_returns_400_bad_docx():
         ],
     )
     assert response.json().get("detail") == "File is not a valid docx"
-    assert response.status_code == 400
+    assert response.status_code == 422
 
 
 def test_general_api_returns_400_bad_json(tmpdir):

--- a/test_general/api/test_app.py
+++ b/test_general/api/test_app.py
@@ -420,7 +420,7 @@ def test_general_api_returns_422_bad_pdf():
     )
 
     assert response.json() == {"detail": "File does not appear to be a valid PDF"}
-    assert response.status_code == 400
+    assert response.status_code == 422
 
 
 def test_general_api_returns_503(monkeypatch):


### PR DESCRIPTION
Closes #326. Differentiate unprocessable entity errors from incorrect parameters, etc.