### PR TITLE
Klaijan/add error detail on GET request

### DIFF
--- a/prepline_general/api/general.py
+++ b/prepline_general/api/general.py
@@ -685,6 +685,15 @@ def ungz_file(file: UploadFile, gz_uncompressed_content_type=None) -> UploadFile
     )
 
 
+@router.get("/general/v0/general")
+@router.get("/general/v0.0.62/general")
+async def handle_invalid_get_request():
+    raise HTTPException(
+        status_code=status.HTTP_405_METHOD_NOT_ALLOWED,
+        detail="Only POST requests are supported."
+    )
+
+
 @router.post("/general/v0/general")
 @router.post("/general/v0.0.62/general")
 def pipeline_1(

--- a/prepline_general/api/general.py
+++ b/prepline_general/api/general.py
@@ -689,8 +689,7 @@ def ungz_file(file: UploadFile, gz_uncompressed_content_type=None) -> UploadFile
 @router.get("/general/v0.0.62/general")
 async def handle_invalid_get_request():
     raise HTTPException(
-        status_code=status.HTTP_405_METHOD_NOT_ALLOWED,
-        detail="Only POST requests are supported."
+        status_code=status.HTTP_405_METHOD_NOT_ALLOWED, detail="Only POST requests are supported."
     )
 
 

--- a/test_general/api/test_app.py
+++ b/test_general/api/test_app.py
@@ -918,3 +918,10 @@ def test_invalid_hi_res_model_name_returns_400():
     )
     assert response.status_code == 400
     assert "Unknown model type" in response.text
+
+
+def test_get_request():
+    client = TestClient(app)
+    response = client.get("/general/v0/general")
+    assert response.status_code == 405
+    assert response.json() == {"detail": "Only POST requests are supported."}


### PR DESCRIPTION
Add a new route handler for handling GET requests for the /general/v0/general. This handler will return the error message that informs user that GET request is not permitted.