### PR TITLE
chore: revert base image change

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:experimental
-FROM quay.io/unstructured-io/base-images:rocky9.2-9@sha256:6c838b65b7e4b3b9a94d56ab92ba5d801f5a530709ffb2ef63ece267955d3140 as base
+FROM quay.io/unstructured-io/base-images:rocky9.2-9@sha256:9e3cbfd93ba940fff2d5f4cc90ca8d431ff040bad037df3b058650f60e14b831 as base
 
 # NOTE(crag): NB_USER ARG for mybinder.org compat:
 #             https://mybinder.readthedocs.io/en/latest/tutorials/dockerfile.html

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:experimental
-FROM quay.io/unstructured-io/base-images:rocky9.2-9@sha256:9e3cbfd93ba940fff2d5f4cc90ca8d431ff040bad037df3b058650f60e14b831 as base
+FROM quay.io/unstructured-io/base-images:rocky9.2-9@sha256:73d8492452f086144d4b92b7931aa04719f085c74d16cae81e8826ef873729c9 as base
 
 # NOTE(crag): NB_USER ARG for mybinder.org compat:
 #             https://mybinder.readthedocs.io/en/latest/tutorials/dockerfile.html


### PR DESCRIPTION
The fix for openssl has been reverted: https://github.com/Unstructured-IO/base-images/pull/13

Need to confirm that this digest is still valid. If the docker test fails in this branch, we'll need to wait until the new image has been built. Edit: yeah, I've written over the existing base-image which may break self hosted users who are building from source with an older dockerfile. Will update the digest once the new image is out.