### PR TITLE
Set Speakeasy max retry time to 5 minutes

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -22,7 +22,7 @@
         "backoff": {
             "initialInterval": 500,
             "maxInterval": 60000,
-            "maxElapsedTime": 3600000,
+            "maxElapsedTime": 300000,
             "exponent": 1.5
         },
         "statusCodes": ["5xx"],

--- a/openapi.json
+++ b/openapi.json
@@ -22,7 +22,7 @@
         "backoff": {
             "initialInterval": 500,
             "maxInterval": 60000,
-            "maxElapsedTime": 300000,
+            "maxElapsedTime": 900000
             "exponent": 1.5
         },
         "statusCodes": ["5xx"],


### PR DESCRIPTION
The clients are doing exponential backoff for up to an hour which is way too long. To verify, we'll need to wait for the client repos to get regenerated.