### PR TITLE
fix(chunking): minimal fix for combine arg typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.63-dev0
+
+* Fix bug that ignored `combine_under_n_chars` chunking option argument.
+
 ## 0.0.62
 
 * Add hi_res_model_name to partition and deprecate model_name

--- a/prepline_general/api/app.py
+++ b/prepline_general/api/app.py
@@ -11,7 +11,7 @@ logger = logging.getLogger("unstructured_api")
 app = FastAPI(
     title="Unstructured Pipeline API",
     description="""""",
-    version="0.0.62",
+    version="0.0.63",
     docs_url="/general/docs",
     openapi_url="/general/openapi.json",
 )

--- a/prepline_general/api/general.py
+++ b/prepline_general/api/general.py
@@ -248,7 +248,7 @@ class ChipperMemoryProtection:
 
 def pipeline_api(
     file,
-    request=None,
+    request: Request,
     filename="",
     file_content_type=None,
     response_type="application/json",
@@ -275,8 +275,14 @@ def pipeline_api(
         file_content_type = "application/x-ole-storage"
 
     # We don't want to keep logging the same params for every parallel call
-    origin_ip = request.headers.get("X-Forwarded-For") or request.client.host
-    is_internal_request = origin_ip.startswith("10.")
+    is_internal_request = (
+        (
+            request.headers.get("X-Forwarded-For")
+            and str(request.headers.get("X-Forwarded-For")).startswith("10.")
+        )
+        # -- NOTE(scanny): request.client is None in certain testing environments --
+        or (request.client and request.client.host.startswith("10."))
+    )
 
     if not is_internal_request:
         logger.debug(

--- a/prepline_general/api/general.py
+++ b/prepline_general/api/general.py
@@ -423,7 +423,7 @@ def pipeline_api(
             "languages": languages,
             "chunking_strategy": chunking_strategy,
             "multipage_sections": multipage_sections,
-            "combine_under_n_chars": combine_under_n_chars,
+            "combine_text_under_n_chars": combine_under_n_chars,
             "new_after_n_chars": new_after_n_chars,
             "max_characters": max_characters,
             "extract_image_block_types": extract_image_block_types,
@@ -692,7 +692,7 @@ def ungz_file(file: UploadFile, gz_uncompressed_content_type=None) -> UploadFile
 
 
 @router.get("/general/v0/general")
-@router.get("/general/v0.0.62/general")
+@router.get("/general/v0.0.63/general")
 async def handle_invalid_get_request():
     raise HTTPException(
         status_code=status.HTTP_405_METHOD_NOT_ALLOWED, detail="Only POST requests are supported."
@@ -700,7 +700,7 @@ async def handle_invalid_get_request():
 
 
 @router.post("/general/v0/general")
-@router.post("/general/v0.0.62/general")
+@router.post("/general/v0.0.63/general")
 def pipeline_1(
     request: Request,
     gz_uncompressed_content_type: Optional[str] = Form(default=None),

--- a/preprocessing-pipeline-family.yaml
+++ b/preprocessing-pipeline-family.yaml
@@ -1,2 +1,2 @@
 name: general
-version: 0.0.62
+version: 0.0.63

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,26 @@
+[tool.black]
+line-length = 100
+
+# changes made here should also be made in `.pre-commit-config.yaml` and `Makefile`
+[tool.ruff]
+line-length = 100
+select = [
+    "C4",       # -- flake8-comprehensions --
+    "COM",      # -- flake8-commas --
+    "E",        # -- pycodestyle errors --
+    "F",        # -- pyflakes --
+    "I",        # -- isort (imports) --
+    "PLR0402",  # -- Name compared with itself like `foo == foo` --
+    "PT",       # -- flake8-pytest-style --
+    "SIM",      # -- flake8-simplify --
+    "UP015",    # -- redundant `open()` mode parameter (like "r" is default) --
+    "UP018",    # -- Unnecessary {literal_type} call like `str("abc")`. (rewrite as a literal) --
+    "UP032",    # -- Use f-string instead of `.format()` call --
+    "UP034",    # -- Avoid extraneous parentheses --
+]
+ignore = [
+    "COM812",   # -- over aggressively insists on trailing commas where not desireable --
+    "PT011",    # -- pytest.raises({exc}) too broad, use match param or more specific exception --
+    "PT012",    # -- pytest.raises() block should contain a single simple statement --
+    "SIM117",   # -- merge `with` statements for context managers that have same scope --
+]

--- a/test_general/api/test_app.py
+++ b/test_general/api/test_app.py
@@ -427,7 +427,7 @@ def test_general_api_returns_503(monkeypatch):
     """
     When available memory is below the minimum. return a 503, unless our origin ip is 10.{4,5}.x.x
     """
-    monkeypatch.setenv("UNSTRUCTURED_MEMORY_FREE_MINIMUM_MB", "30000")
+    monkeypatch.setenv("UNSTRUCTURED_MEMORY_FREE_MINIMUM_MB", "300000")
 
     client = TestClient(app)
     test_file = Path("sample-docs") / "fake-xml.xml"

--- a/test_general/api/test_app.py
+++ b/test_general/api/test_app.py
@@ -537,7 +537,7 @@ def test_parallel_mode_passes_params(monkeypatch):
         skip_infer_table_types="foo",
         chunking_strategy="by_title",
         multipage_sections=False,
-        combine_under_n_chars=501,
+        combine_text_under_n_chars=501,
         new_after_n_chars=1501,
         max_characters=1502,
         extract_image_block_types=None,


### PR DESCRIPTION
This is the minimal fix for the `combine_text_under_n_chars` arg-name typo bug described in #337.

Chunking parameters were added to the API about 4 months ago in this commit: https://github.com/Unstructured-IO/unstructured-api/commit/49fe71026e026530276bbb72f6a9df46feb6d1c2

At that time, the identifier `combine_under_n_chars` was used instead of `combine_text_under_n_chars` (as that parameter appears in `chunk_by_title()`). As a result, any value supplied for this argument via the REST API is ignored and defaults to 500. The `combine_under_n_chars` parameter name  appears in the API documentation and elsewhere (README.md etc.) and differs from the parameter name documented for `chunk_by_title()`.

A fuller remedy will be to add a separate `combine_text_under_n_chars` parameter to the API endpoint such that either name is accepted for now, then update the documentation such that all mentions are `combine_text_under_n_chars`. At some point in the future we may remove the `combine_under_n_chars` parameter from the endpoint.

However, making those changes requires a synchronized release of the `unstructured` library and in the interest of time we're making this "quick-fix" that can be released independently of any other dependencies.