### PR TITLE
feat: hide GET helper handlers in swagger/schema

### DIFF
--- a/prepline_general/api/general.py
+++ b/prepline_general/api/general.py
@@ -691,8 +691,8 @@ def ungz_file(file: UploadFile, gz_uncompressed_content_type=None) -> UploadFile
     )
 
 
-@router.get("/general/v0/general")
-@router.get("/general/v0.0.63/general")
+@router.get("/general/v0/general", include_in_schema=False)
+@router.get("/general/v0.0.63/general", include_in_schema=False)
 async def handle_invalid_get_request():
     raise HTTPException(
         status_code=status.HTTP_405_METHOD_NOT_ALLOWED, detail="Only POST requests are supported."


### PR DESCRIPTION
Added `include_in_schema=False` in corresponding handlers

<img width="1493" alt="Screenshot 2024-01-24 at 16 00 01" src="https://github.com/Unstructured-IO/unstructured-api/assets/80269173/47d6ac6c-c519-4c40-b728-abbce8d5f0dd">

Resolves #347 