### PR TITLE
enhancement: add yaml to default mime types

### DIFF
--- a/prepline_general/api/general.py
+++ b/prepline_general/api/general.py
@@ -84,10 +84,10 @@ DEFAULT_MIMETYPES = (
     "application/xml,text/xml,text/x-rst,text/prs.fallenstein.rst,"
     "text/tsv,text/tab-separated-values,"
     "application/x-ole-storage,application/vnd.ms-outlook,"
-    "application/yaml",
-    "application/x-yaml",
-    "text/x-yaml",
-    "text/yaml",
+    "application/yaml,"
+    "application/x-yaml,"
+    "text/x-yaml,"
+    "text/yaml,"
 )
 
 if not os.environ.get("UNSTRUCTURED_ALLOWED_MIMETYPES", None):

--- a/prepline_general/api/general.py
+++ b/prepline_general/api/general.py
@@ -84,6 +84,10 @@ DEFAULT_MIMETYPES = (
     "application/xml,text/xml,text/x-rst,text/prs.fallenstein.rst,"
     "text/tsv,text/tab-separated-values,"
     "application/x-ole-storage,application/vnd.ms-outlook,"
+    "application/yaml",
+    "application/x-yaml",
+    "text/x-yaml",
+    "text/yaml",
 )
 
 if not os.environ.get("UNSTRUCTURED_ALLOWED_MIMETYPES", None):


### PR DESCRIPTION
### Summary

Related to https://github.com/Unstructured-IO/unstructured/pull/2446 . Adds YAML to the list of default MIME types. Had originally through to dynamically build the list from the MIME types in `unstructured`, but there are some MIME types (like `audio/wav` that are currently support for filetype detection but not `partition`. Probably want to be deliberate about adding those.