### PR TITLE
Fix typo in openapi.json

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -22,7 +22,7 @@
         "backoff": {
             "initialInterval": 500,
             "maxInterval": 60000,
-            "maxElapsedTime": 900000
+            "maxElapsedTime": 900000,
             "exponent": 1.5
         },
         "statusCodes": ["5xx"],


### PR DESCRIPTION
This was caught by the speakeasy regen job: https://github.com/Unstructured-IO/unstructured-python-client/actions/runs/7647985274/job/20839951777