### PR TITLE
Hide the versioned endpoint in the Swagger doc

### DIFF
--- a/prepline_general/api/general.py
+++ b/prepline_general/api/general.py
@@ -721,7 +721,7 @@ async def handle_invalid_get_request():
 
 
 @router.post("/general/v0/general")
-@router.post("/general/v0.0.63/general")
+@router.post("/general/v0.0.63/general", include_in_schema=False)
 def pipeline_1(
     request: Request,
     gz_uncompressed_content_type: Optional[str] = Form(default=None),


### PR DESCRIPTION
The /general/v0.0.x/general path will change when we deploy a new version. This only serves to cause 404s for the users.