### PR TITLE
test: extract_image_block_types parameter usage

### DIFF
--- a/test_general/api/test_app.py
+++ b/test_general/api/test_app.py
@@ -381,7 +381,14 @@ def test_include_page_breaks_param():
     assert response_without_page_breaks[-1]["type"] != "PageBreak"
 
 
-def test_include_extract_image_block_types_param():
+@pytest.mark.parametrize(
+    "extract_image_block_types",
+    [
+        '["Image", "Table"]',
+        ["Image", "Table"],
+    ],
+)
+def test_include_extract_image_block_types_param(extract_image_block_types):
     """
     Verify that responses do not include base64 image in Table/Image metadata unless requested.
     """
@@ -401,7 +408,7 @@ def test_include_extract_image_block_types_param():
         response = client.post(
             MAIN_API_ROUTE,
             files=[("files", (str(test_file), file))],
-            data={"strategy": "hi_res", "extract_image_block_types": '["Image", "Table"]'},
+            data={"strategy": "hi_res", "extract_image_block_types": extract_image_block_types},
         )
 
     assert response.status_code == 200


### PR DESCRIPTION
This PR updates the unit test function to test if image metadata `image_base64` and `image_mime_type` are present when `extract_image_block_types` parameter is given.