### PR TITLE
fix: build and push workflow failing due to missing `-f` option `buildx build` command

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -69,7 +69,7 @@ jobs:
         sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/share/boost
 
         ARCH=$(cut -d "/" -f2 <<< ${{ matrix.docker-platform }})
-        DOCKER_BUILDKIT=1 docker buildx build --platform=$ARCH --load \
+        DOCKER_BUILDKIT=1 docker buildx build --platform=$ARCH --load -f Dockerfile-$ARCH \
           --build-arg PIP_VERSION=$PIP_VERSION \
           --build-arg BUILDKIT_INLINE_CACHE=1 \
           --build-arg PIPELINE_PACKAGE=${{ env.PIPELINE_FAMILY }} \

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -76,8 +76,8 @@ jobs:
           --build-arg PIPELINE_PACKAGE=${{ env.PIPELINE_FAMILY }} \
           --provenance=false \
           --progress plain \
-          --cache-from $DOCKER_BUILD_REPOSITORY:$ARCH \
-          -t $DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA .
+          --cache-from $DOCKER_BUILD_REPOSITORY:${{ matrix.arch }} \
+          -t $DOCKER_BUILD_REPOSITORY:${{ matrix.arch }}-$SHORT_SHA .
     - name: Set virtualenv cache
       uses: actions/cache@v4
       id: virtualenv-cache
@@ -99,7 +99,7 @@ jobs:
     - name: Push image
       run: |
         # write to the build repository to cache for the publish-images job
-        docker push $DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA
+        docker push $DOCKER_BUILD_REPOSITORY:${{ matrix.arch }}-$SHORT_SHA
   publish-images:
     runs-on: ubuntu-latest-m
     needs: [setup, set-short-sha, build-images]

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -45,16 +45,17 @@ jobs:
   build-images:
     strategy:
       matrix:
-        docker-platform: ["linux/arm64", "linux/amd64"]
+        arch: ["arm64", "amd64"]
     runs-on: ubuntu-latest-m
     needs: [setup, set-short-sha]
     env:
       SHORT_SHA: ${{ needs.set-short-sha.outputs.short_sha }}
+      DOCKER_PLATFORM: linux/${{ matrix.arch }}
     steps:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
       with:
-        driver: ${{ matrix.docker-platform == 'linux/amd64' && 'docker' || 'docker-container' }}
+        driver: ${{ matrix.arch == 'amd64' && 'docker' || 'docker-container' }}
     - name: Checkout code
       uses: actions/checkout@v4
     - name: Login to Quay.io
@@ -68,8 +69,8 @@ jobs:
         # Clear some space (https://github.com/actions/runner-images/issues/2840)
         sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/share/boost
 
-        ARCH=$(cut -d "/" -f2 <<< ${{ matrix.docker-platform }})
-        DOCKER_BUILDKIT=1 docker buildx build --platform=$ARCH --load -f Dockerfile-$ARCH \
+        DOCKER_BUILDKIT=1 docker buildx build --load -f Dockerfile-${{ matrix.arch }} \
+          --platform=$DOCKER_PLATFORM \
           --build-arg PIP_VERSION=$PIP_VERSION \
           --build-arg BUILDKIT_INLINE_CACHE=1 \
           --build-arg PIPELINE_PACKAGE=${{ env.PIPELINE_FAMILY }} \
@@ -88,19 +89,16 @@ jobs:
       uses: docker/setup-qemu-action@v3
     - name: Test image
       run: |
-        ARCH=$(cut -d "/" -f2 <<< ${{ matrix.docker-platform }})
         source .venv/bin/activate
-        if [ "${{ matrix.docker-platform }}" == "linux/arm64" ]; then
-          DOCKER_PLATFORM="${{ matrix.docker-platform }}" DOCKER_IMAGE="$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA" \
+        DOCKER_IMAGE="$DOCKER_BUILD_REPOSITORY:${{ matrix.arch }}-$SHORT_SHA" \
+        if [ "$DOCKER_PLATFORM" == "linux/arm64" ]; then
           SKIP_INFERENCE_TESTS=true make docker-test
         else
-          DOCKER_PLATFORM="${{ matrix.docker-platform }}" DOCKER_IMAGE="$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA" \
           make docker-test
         fi
     - name: Push image
       run: |
         # write to the build repository to cache for the publish-images job
-        ARCH=$(cut -d "/" -f2 <<< ${{ matrix.docker-platform }})
         docker push $DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA
   publish-images:
     runs-on: ubuntu-latest-m

--- a/Dockerfile-amd64
+++ b/Dockerfile-amd64
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:experimental
-FROM quay.io/unstructured-io/base-images:wolfi-base@sha256:6c00a236c648ffdaf196ccbc446f5c6cc9eb4e3ab9e437178abcfac710b2b373 as base
+FROM quay.io/unstructured-io/base-images:wolfi-base@sha256:863fd5b87e780dacec62b97c2db2aeda7f770fcf9b045b29f53ec1ddbe607b4d as base
 
 # NOTE(crag): NB_USER ARG for mybinder.org compat:
 #             https://mybinder.readthedocs.io/en/latest/tutorials/dockerfile.html


### PR DESCRIPTION
I noticed that images on main branch are failing to build (and push) due to missing `-f` parameter in `docker buildx build`. By default it expects `Dockerfile` to exist, but we only have `Dockerfile-amd64` and `Dockerfile-arm64`

![image](https://github.com/Unstructured-IO/unstructured-api/assets/64484917/4527165a-909e-498d-b0ee-8bba4b1a13e4)
