### PR TITLE
fix: revert to rockylinux SHA that works (arm64)

### DIFF
--- a/Dockerfile-arm64
+++ b/Dockerfile-arm64
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:experimental
-FROM quay.io/unstructured-io/base-images:rocky9.2-9@sha256:66f84447138b893b272e75044f9967379de3e874849cb2b9cb7aa2b3e9dea4e6 as base
+FROM quay.io/unstructured-io/base-images:rocky9.2-9@sha256:73d8492452f086144d4b92b7931aa04719f085c74d16cae81e8826ef873729c9 as base
 
 # NOTE(crag): NB_USER ARG for mybinder.org compat:
 #             https://mybinder.readthedocs.io/en/latest/tutorials/dockerfile.html


### PR DESCRIPTION
unnecessary SHA update introduced in https://github.com/Unstructured-IO/unstructured-api/pull/427 that needs to be reverted