### PR TITLE
fix: re-add `DOCKER_IMAGE` env var in `Test image` step

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -88,9 +88,10 @@ jobs:
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
     - name: Test image
+      env:
+        DOCKER_IMAGE: "$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA"
       run: |
         source .venv/bin/activate
-        DOCKER_IMAGE="$DOCKER_BUILD_REPOSITORY:${{ matrix.arch }}-$SHORT_SHA" \
         if [ "$DOCKER_PLATFORM" == "linux/arm64" ]; then
           SKIP_INFERENCE_TESTS=true make docker-test
         else


### PR DESCRIPTION
shell syntax error occurs in docker-publish.yml workflow