### PR TITLE
Fix pylint warning `no-else-return`

### DIFF
--- a/prepline_general/api/general.py
+++ b/prepline_general/api/general.py
@@ -696,8 +696,7 @@ def ungz_file(file: UploadFile, gz_uncompressed_content_type: Optional[str] = No
     def return_content_type(filename: str):
         if gz_uncompressed_content_type:
             return gz_uncompressed_content_type
-        else:
-            return str(mimetypes.guess_type(filename)[0])
+        return str(mimetypes.guess_type(filename)[0])
 
     filename = str(file.filename) if file.filename else ""
     if filename.endswith(".gz"):

--- a/prepline_general/api/utils.py
+++ b/prepline_general/api/utils.py
@@ -53,8 +53,7 @@ def is_convertible_to_list(s: str) -> Tuple[bool, Union[List, str]]:
         result = json.loads(s)
         if isinstance(result, list):
             return True, result  # Return the list if conversion is successful
-        else:
-            return False, "Input is valid JSON but not a list."  # Valid JSON but not a list
+        return False, "Input is valid JSON but not a list."  # Valid JSON but not a list
     except json.JSONDecodeError:
         pass  # proceed to check using delimiters if JSON parsing fails
 
@@ -86,7 +85,7 @@ class SmartValueParser(Generic[T]):
         if isinstance(value, list) and not isinstance(value, origin_class):
             extracted_value: T | None = _return_cast_first_element(value, origin_class)
             return extracted_value
-        elif isinstance(value, list) and origin_class == list and container_elems_class:
+        if isinstance(value, list) and origin_class == list and container_elems_class:
             if len(value) == 1:
                 is_list, result = is_convertible_to_list(str(value[0]))
                 new_value = result if is_list else value


### PR DESCRIPTION
Changes Made:

- Applied automated fixes for the pylint warning `no-else-return`.
"Used in order to highlight an unnecessary block of code following an if containing a return statement. As such, it will warn when it encounters an else following a chain of ifs, all of them containing a return statement.. See [https://pylint.pycqa.org/en/latest/user_guide/messages/refactor/no-else-return.html](https://pylint.pycqa.org/en/latest/user_guide/messages/refactor/no-else-return.html)"

Note:

This pull request is part of a research project conducted by researchers from TU Delft, titled "PyWarnFixer: Using ML to Fix Pylint Warnings." The goal of this study is to investigate the perceptions and practices of code quality among developers in Python open-source projects and to develop a tool that uses AI to automatically fix pylint warnings.

### Research Study Information:
This pull request is part of a research project. For more information about the study, please visit the [project's information page](https://github.com/RatishT/PyWarnFixer/blob/main/README.md).

### Consent to Participate:
If you review this pull request, you are invited to participate in our study. Your participation is voluntary. To provide your consent, just open an issue in our repository with the provided template using the following link: [consent issue template](https://github.com/RatishT/PyWarnFixer/issues/new/choose) .

---

Thank you for considering participation in our research. Your feedback is crucial and highly valued. If you have any questions or concerns, please contact the Responsible Researcher at R.K.Thakoersingh@student.tudelft.nl.