### PR TITLE
feat: add prometheus metrics to /metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.82
+
+* Expose Prometheus metrics at /metrics
+
 ## 0.0.81
 
 * Update `strategy` parameter to allow `'` and `"` as input surrounding the value.

--- a/prepline_general/api/app.py
+++ b/prepline_general/api/app.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI, Request, status, HTTPException
 from fastapi.datastructures import FormData
 from fastapi.responses import JSONResponse
 from fastapi.security import APIKeyHeader
+from prometheus_client import make_asgi_app
 import logging
 import os
 
@@ -13,7 +14,7 @@ logger = logging.getLogger("unstructured_api")
 app = FastAPI(
     title="Unstructured Pipeline API",
     summary="Partition documents with the Unstructured library",
-    version="0.0.81",
+    version="0.0.82",
     docs_url="/general/docs",
     openapi_url="/general/openapi.json",
     servers=[
@@ -30,6 +31,9 @@ app = FastAPI(
     ],
     openapi_tags=[{"name": "general"}],
 )
+
+metrics_app = make_asgi_app()
+app.mount("/metrics", metrics_app)
 
 # Note(austin) - This logger just dumps exceptions
 # We'd rather handle those below, so disable this in deployments

--- a/prepline_general/api/general.py
+++ b/prepline_general/api/general.py
@@ -653,7 +653,7 @@ def ungz_file(file: UploadFile, gz_uncompressed_content_type: Optional[str] = No
 
 
 @router.get("/general/v0/general", include_in_schema=False)
-@router.get("/general/v0.0.81/general", include_in_schema=False)
+@router.get("/general/v0.0.82/general", include_in_schema=False)
 async def handle_invalid_get_request():
     raise HTTPException(
         status_code=status.HTTP_405_METHOD_NOT_ALLOWED, detail="Only POST requests are supported."
@@ -668,7 +668,7 @@ async def handle_invalid_get_request():
     description="Description",
     operation_id="partition_parameters",
 )
-@router.post("/general/v0.0.81/general", include_in_schema=False)
+@router.post("/general/v0.0.82/general", include_in_schema=False)
 def general_partition(
     request: Request,
     # cannot use annotated type here because of a bug described here:

--- a/preprocessing-pipeline-family.yaml
+++ b/preprocessing-pipeline-family.yaml
@@ -1,2 +1,2 @@
 name: general
-version: 0.0.81
+version: 0.0.82

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -16,3 +16,4 @@ backoff
 pypdf
 pycryptodome
 psutil
+prometheus_client

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -244,6 +244,8 @@ pillow==10.4.0
     #   unstructured-pytesseract
 portalocker==2.10.1
     # via iopath
+prometheus-client==0.21.0
+    # via -r requirements/base.in
 proto-plus==1.24.0
     # via
     #   google-api-core


### PR DESCRIPTION
# Summary
This PR adds the Prometheus Python client as a dependency, and serves up the out-of-the-box metrics on the `/metrics` endpoint.

The metrics mounting code was taken almost directly from Prometheus' documentation on how to add metrics to a FastAPI application: https://prometheus.github.io/client_python/exporting/http/fastapi-gunicorn/

Since this would be my first contribution and in an effort to keep the change on the small side, this PR does not expose any custom metrics.

# Testing
- `make docker-test`, `make check` pass
- Manually verified the metrics by running `make docker-start-api` and observing the metrics at [http://localhost:8000/metrics](http://localhost:8000/metrics)
<details><summary>Example output</summary>

```
# HELP python_gc_objects_collected_total Objects collected during gc
# TYPE python_gc_objects_collected_total counter
python_gc_objects_collected_total{generation="0"} 10468.0
python_gc_objects_collected_total{generation="1"} 4124.0
python_gc_objects_collected_total{generation="2"} 2134.0
# HELP python_gc_objects_uncollectable_total Uncollectable objects found during GC
# TYPE python_gc_objects_uncollectable_total counter
python_gc_objects_uncollectable_total{generation="0"} 0.0
python_gc_objects_uncollectable_total{generation="1"} 0.0
python_gc_objects_uncollectable_total{generation="2"} 0.0
# HELP python_gc_collections_total Number of times this generation was collected
# TYPE python_gc_collections_total counter
python_gc_collections_total{generation="0"} 952.0
python_gc_collections_total{generation="1"} 86.0
python_gc_collections_total{generation="2"} 6.0
# HELP python_info Python platform information
# TYPE python_info gauge
python_info{implementation="CPython",major="3",minor="11",patchlevel="10",version="3.11.10"} 1.0
# HELP process_virtual_memory_bytes Virtual memory size in bytes.
# TYPE process_virtual_memory_bytes gauge
process_virtual_memory_bytes 4.717744128e+09
# HELP process_resident_memory_bytes Resident memory size in bytes.
# TYPE process_resident_memory_bytes gauge
process_resident_memory_bytes 8.1219584e+08
# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
# TYPE process_start_time_seconds gauge
process_start_time_seconds 1.72882768797e+09
# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
# TYPE process_cpu_seconds_total counter
process_cpu_seconds_total 9.059999999999999
# HELP process_open_fds Number of open file descriptors.
# TYPE process_open_fds gauge
process_open_fds 20.0
# HELP process_max_fds Maximum number of open file descriptors.
# TYPE process_max_fds gauge
process_max_fds 1.048576e+06
```
</details>
