### PR TITLE
Fix Docker image for usage on Azure AppService 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,12 +12,16 @@ ARG PYTHON_VERSION="3.11"
 # Set up environment
 ENV PYTHON python${PYTHON_VERSION}
 ENV PIP ${PYTHON} -m pip
+ENV PYTHONUSERBASE /opt/env
 
-WORKDIR ${HOME}
+USER root
+RUN chown ${NB_USER}:${NB_USER} /opt
+
+WORKDIR /opt
 USER ${NB_USER}
 
-ENV PYTHONPATH="${PYTHONPATH}:${HOME}"
-ENV PATH="/home/${NB_USER}/.local/bin:${PATH}"
+ENV PYTHONPATH="${PYTHONPATH}:/opt"
+ENV PATH="/opt/env/bin:${PATH}"
 
 FROM base as python-deps
 COPY --chown=${NB_USER}:${NB_USER} requirements/base.txt requirements-base.txt


### PR DESCRIPTION
Since the official unstructured-api image doesn´t work on Azure AppServices, the pip and app files must be moved from the _home/notebook-user_ folder to another folder on the system (in this case _/opt_).

It seems that Azure tries to mount or modify the home directory in our container with contents from their kudu OS, which leads to an empty _/home/notebook-user_ folder.

The error message in azure looks as follows:
```
ERROR - Container start failed for {APP_SERVICE_INSTANCE} with System.AggregateException, One or more errors occurred. 
(Docker API responded with status code=BadRequest, response={"message":"failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: \"scripts/app-start.sh\": stat scripts/app-start.sh: no such file or directory: unknown"})
InnerException: Docker.DotNet.DockerApiException, Docker API responded with status code=BadRequest, response={"message":"failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: \"scripts/app-start.sh\": stat scripts/app-start.sh: no such file or directory: unknown"}
```