### PR TITLE
disable arm build due to failing ci

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -45,7 +45,9 @@ jobs:
   build-images:
     strategy:
       matrix:
-        arch: ["arm64", "amd64"]
+        #arch: ["arm64", "amd64"]
+        # NOTE(luke): temporary disable arm64 since its failing the smoke test
+        arch: ["amd64"]
     runs-on: ubuntu-latest-m
     needs: [setup, set-short-sha]
     env:

--- a/scripts/docker-smoke-test.sh
+++ b/scripts/docker-smoke-test.sh
@@ -29,8 +29,9 @@ start_container() {
     fi
 
     echo Starting container "$name"
-    docker run -p "$port":"$port" \
-	   --entrypoint uvicorn \
+    docker run --platform "$DOCKER_PLATFORM" \
+           -p "$port":"$port" \
+           --entrypoint uvicorn \
            -d \
            --rm \
            --name "$name" \


### PR DESCRIPTION
temp disable the ARM64 build until it can be determined why its failing the CI. Need to get an updated amd64 build to quay