### PR TITLE
Add support for 'basic' chunking strategy to match documentation

### DIFF
--- a/prepline_general/api/models/form_params.py
+++ b/prepline_general/api/models/form_params.py
@@ -178,11 +178,11 @@ class GeneralFormParams(BaseModel):
         ] = False,
         # -- chunking options --
         chunking_strategy: Annotated[
-            Optional[Literal["by_title"]],
+            Optional[Literal["by_title", "basic"]],
             Form(
                 title="Chunking Strategy",
-                description="Use one of the supported strategies to chunk the returned elements. Currently supports: by_title",
-                examples=["by_title"],
+                description="Use one of the supported strategies to chunk the returned elements. Currently supports: by_title and basic. Default: None",
+                examples=["by_title", "basic"],
             ),
         ] = None,
         combine_under_n_chars: Annotated[

--- a/test_general/api/test_app.py
+++ b/test_general/api/test_app.py
@@ -1153,3 +1153,30 @@ def test_include_slide_notes(monkeypatch, test_default, include_slide_notes, tes
         assert "Here are important notes" == df["text"][0]
     else:
         assert "Here are important notes" != df["text"][0]
+
+def test_basic_chunking_strategy():
+    """
+    Verify that basic chunking strategy works as expected
+    """
+    client = TestClient(app)
+    test_file = Path("sample-docs") / "layout-parser-paper-fast.pdf"
+    response = client.post(
+        MAIN_API_ROUTE,
+        files=[("files", (str(test_file), open(test_file, "rb")))],
+        data={"strategy": "hi_res"},
+    )
+    assert response.status_code == 200
+    response_without_chunking = response.json()
+
+    # chunking
+    response = client.post(
+        MAIN_API_ROUTE,
+        files=[("files", (str(test_file), open(test_file, "rb")))],
+        data={"chunking_strategy": "basic"},
+    )
+    assert response.status_code == 200
+
+    response_with_chunking = response.json()
+    assert len(response_with_chunking) != len(response_without_chunking)
+    assert "CompositeElement" in [element.get("type") for element in response_with_chunking]
+


### PR DESCRIPTION
**Problem Statement**
The unstructured-api currently lacks support for the 'basic' chunking strategy, which is mentioned in the official documentation. As per the documentation, the API should allow users to choose between different chunking strategies, such as "by_title" and "basic". However, the chunking_strategy parameter in the API currently only supports 'by_title', causing a mismatch between the functionality described in the documentation and the actual behavior of the system.

**Solution**
Updating the chunking_strategy parameter: The chunking_strategy parameter is modified to support both 'by_title' and 'basic' chunking strategies, as indicated by the official documentation.

The Literal type hint for chunking_strategy is updated to include both 'by_title' and 'basic' as valid options.

This update ensures that the API accepts 'basic' as a valid chunking strategy and prevents potential issues with incorrect values.

**Why this PR should be accepted**
This pull request resolves a key issue by ensuring that the unstructured-api behaves consistently with the documented features, particularly by adding support for the 'basic' chunking strategy.