### PR TITLE
Update h11 to remove vulnerability

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -98,7 +98,7 @@ grpcio==1.70.0
     #   grpcio-status
 grpcio-status==1.70.0
     # via google-api-core
-h11==0.14.0
+h11==0.16.0
     # via
     #   httpcore
     #   uvicorn

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -104,7 +104,7 @@ h11==0.16.0
     #   uvicorn
 html5lib==1.1
     # via unstructured
-httpcore==1.0.7
+httpcore==1.0.9
     # via httpx
 httpx==0.28.1
     # via unstructured-client

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -213,7 +213,7 @@ grpcio-status==1.70.0
     # via
     #   -r requirements/base.txt
     #   google-api-core
-h11==0.14.0
+h11==0.16.0
     # via
     #   -r requirements/base.txt
     #   httpcore

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -222,7 +222,7 @@ html5lib==1.1
     # via
     #   -r requirements/base.txt
     #   unstructured
-httpcore==1.0.7
+httpcore==1.0.9
     # via
     #   -r requirements/base.txt
     #   httpx


### PR DESCRIPTION
From the CVE scan report:
```
#!/usr/bin/env bash

# python version must match lowest supported (3.9)
major=3
minor=9
if ! python -c "import sys; assert sys.version_info.major == $major and sys.version_info.minor == $minor"; then
  echo "python version not equal to expected $major.$minor: $(python --version)"
  exit 1
fi

# Determine the directory of the script
SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

# Use relative paths based on the script's directory
pushd "$SCRIPT_DIR/../requirements" || exit
make clean
make all
popd || exit
```