### PR TITLE
Improved versioning

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -131,6 +131,11 @@ jobs:
         docker push $DOCKER_BUILD_REPOSITORY:amd64
         #docker tag $DOCKER_BUILD_REPOSITORY:arm64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:arm64
         #docker push $DOCKER_BUILD_REPOSITORY:arm64
+    - name: Extract version from __version__.py
+      id: extract-version
+      run: |
+        VERSION=$(grep -oP "(?<=^__version__ = ')[^']+" prepline_general/__version__.py)
+        echo "VERSION=$VERSION" >> $GITHUB_ENV
     - name: Push multiarch manifest
       run: |
         #docker manifest create ${DOCKER_REPOSITORY}:latest $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:arm64
@@ -139,7 +144,6 @@ jobs:
         #docker manifest create ${DOCKER_REPOSITORY}:$SHORT_SHA $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:arm64
         docker manifest create ${DOCKER_REPOSITORY}:$SHORT_SHA $DOCKER_BUILD_REPOSITORY:amd64
         docker manifest push $DOCKER_REPOSITORY:$SHORT_SHA
-        VERSION=$(grep -m1 version preprocessing-pipeline-family.yaml | cut -d ' ' -f2)
         #docker manifest create ${DOCKER_REPOSITORY}:$VERSION $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:arm64
         docker manifest create ${DOCKER_REPOSITORY}:$VERSION $DOCKER_BUILD_REPOSITORY:amd64
         docker manifest push ${DOCKER_REPOSITORY}:$VERSION

--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,6 @@ check-version:
 # Fail if syncing version would produce changes
 	scripts/version-sync.sh -c \
 		-s CHANGELOG.md \
-		-f preprocessing-pipeline-family.yaml release \
 		-f ${PACKAGE_NAME}/api/app.py release \
 		-f ${PACKAGE_NAME}/api/general.py release
 
@@ -145,6 +144,5 @@ check-version:
 version-sync:
 	scripts/version-sync.sh \
 		-s CHANGELOG.md \
-		-f preprocessing-pipeline-family.yaml release \
 		-f ${PACKAGE_NAME}/api/app.py release \
 		-f ${PACKAGE_NAME}/api/general.py release

--- a/prepline_general/__version__.py
+++ b/prepline_general/__version__.py
@@ -1,0 +1,1 @@
+__version__ = "0.0.85"  # pragma: no cover

--- a/prepline_general/api/general.py
+++ b/prepline_general/api/general.py
@@ -33,6 +33,7 @@ from pypdf.errors import FileNotDecryptedError, PdfReadError
 from starlette.datastructures import Headers
 from starlette.types import Send
 
+from prepline_general.__version__ import __version__ as API_VERSION
 from prepline_general.api.models.form_params import GeneralFormParams
 from prepline_general.api.filetypes import get_validated_mimetype
 from unstructured.documents.elements import Element
@@ -602,7 +603,7 @@ def ungz_file(file: UploadFile, gz_uncompressed_content_type: Optional[str] = No
 
 
 @router.get("/general/v0/general", include_in_schema=False)
-@router.get("/general/v0.0.84/general", include_in_schema=False)
+@router.get(f"/general/{API_VERSION}/general", include_in_schema=False)
 async def handle_invalid_get_request():
     raise HTTPException(
         status_code=status.HTTP_405_METHOD_NOT_ALLOWED, detail="Only POST requests are supported."
@@ -617,7 +618,7 @@ async def handle_invalid_get_request():
     description="Description",
     operation_id="partition_parameters",
 )
-@router.post("/general/v0.0.84/general", include_in_schema=False)
+@router.post(f"/general/{API_VERSION}/general", include_in_schema=False)
 def general_partition(
     request: Request,
     # cannot use annotated type here because of a bug described here:

--- a/preprocessing-pipeline-family.yaml
+++ b/preprocessing-pipeline-family.yaml
@@ -1,2 +1,0 @@
-name: general
-version: 0.0.84


### PR DESCRIPTION
This PR addresses the following issues:
- Multiple sources of truth for the API version
- Docker image version derived from `preprocess_pipeline_family.yaml` that is not used for anything else

The changes introduced:
- A single `__version__.py` file that is a single source of truth for the entire repo
- Removed `preprocess_pipeline_family.yaml` as it's just an unnecessary step in setting our docker image version