### PR TITLE
fix: add additional cleanup in docker publish workflow, running out of runner space

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -66,11 +66,28 @@ jobs:
         registry: quay.io
         username: ${{ secrets.QUAY_IO_ROBOT_USERNAME }}
         password: ${{ secrets.QUAY_IO_ROBOT_TOKEN }}
-    - name: Build image
+    - name: Free up disk space
       run: |
         # Clear some space (https://github.com/actions/runner-images/issues/2840)
-        sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/share/boost
+        echo "Disk usage before cleanup:"
+        df -h
 
+        # Remove unnecessary pre-installed software
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /opt/ghc
+        sudo rm -rf /usr/local/share/boost
+        sudo rm -rf /usr/local/lib/android
+        sudo rm -rf /opt/hostedtoolcache/CodeQL
+        sudo rm -rf /usr/local/.ghcup
+        sudo rm -rf /usr/share/swift
+
+        # Clean up docker to ensure we start fresh
+        docker system prune -af --volumes
+
+        echo "Disk usage after cleanup:"
+        df -h
+    - name: Build image
+      run: |
         DOCKER_BUILDKIT=1 docker buildx build --load -f Dockerfile \
           --platform=$DOCKER_PLATFORM \
           --build-arg PIP_VERSION=$PIP_VERSION \


### PR DESCRIPTION
Same code applied to the CI workflow in a previous PR but it's required on the docker publish workflow as well due to the limited github runner disk space

https://github.com/Unstructured-IO/unstructured-api/blob/main/.github/workflows/ci.yml#L120-L140

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces proactive disk cleanup to prevent runner out-of-space failures during image builds.
> 
> - Adds `Free up disk space` step in `docker-publish.yml` that removes large preinstalled toolchains (e.g., `dotnet`, `ghc`, `boost`, Android, CodeQL, `ghcup`, Swift) and runs `docker system prune -af --volumes`, logging `df -h` before/after
> - Keeps the existing image build logic intact, now executed in a subsequent `Build image` step
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 20d2aefe052998dc896c17292893ec62e060937d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->