### PR TITLE
fix: correct invalid JSON in Swagger UI examples for list parameters

### DIFF
--- a/prepline_general/api/models/form_params.py
+++ b/prepline_general/api/models/form_params.py
@@ -54,7 +54,7 @@ class GeneralFormParams(BaseModel):
             Form(
                 title="OCR Languages",
                 description="The languages present in the document, for use in partitioning and/or OCR",
-                examples=["[eng]"],
+                examples=['["eng"]'],
             ),
             BeforeValidator(SmartValueParser[List[str]]().value_or_first_element),
         ] = [],  # noqa
@@ -63,7 +63,7 @@ class GeneralFormParams(BaseModel):
             Form(
                 title="OCR Languages",
                 description="The languages present in the document, for use in partitioning and/or OCR",
-                examples=["[eng]"],
+                examples=['["eng"]'],
             ),
             BeforeValidator(SmartValueParser[List[str]]().value_or_first_element),
         ] = [],
@@ -74,7 +74,7 @@ class GeneralFormParams(BaseModel):
                 description=(
                     "The document types that you want to skip table extraction with. Default: []"
                 ),
-                examples=["['pdf', 'jpg', 'png']"],
+                examples=['["pdf", "jpg", "png"]'],
             ),
             BeforeValidator(SmartValueParser[List[str]]().value_or_first_element),
         ] = [],  # noqa


### PR DESCRIPTION
The examples for languages, ocr_languages, and skip_infer_table_types parameters were using invalid JSON syntax (e.g., "[eng]" instead of '["eng"]'). This caused Swagger UI to fail rendering the /general/doc endpoint with the error: "Unexpected token 'e', \"[eng]\" is not valid JSON"

Changed:
- languages: "[eng]" -> '["eng"]'
- ocr_languages: "[eng]" -> '["eng"]'
- skip_infer_table_types: "['pdf', 'jpg', 'png']" -> '["pdf", "jpg", "png"]'

These parameters use multipart/form-data which requires stringified JSON for array values. The fix uses proper JSON syntax with double quotes, matching the pattern used elsewhere (e.g., extract_image_block_types).

Fixes #537

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Doc/Swagger example-only updates to form parameter metadata; no runtime logic or request parsing changes.
> 
> **Overview**
> Fixes invalid JSON shown in Swagger UI examples for multipart/form-data list parameters in `GeneralFormParams.as_form`.
> 
> Updates the `examples` strings for `languages`, `ocr_languages`, and `skip_infer_table_types` to use proper JSON array syntax (double-quoted strings), preventing Swagger UI rendering errors for the `/general/doc` endpoint.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f408553c3a18b039b487e72eb9c7b01c726e6ff7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->