### PR TITLE
fix(docker): replace PyPI opencv wheel with ffmpeg-free build [security]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.1.4
+
+### Security
+
+- **Replace PyPI opencv wheels with ffmpeg-free builds in Docker image**: After `uv sync`, the Dockerfile now substitutes the installed PyPI opencv-python variant with a source-built `opencv-contrib-python-headless` wheel compiled with `WITH_FFMPEG=OFF`, eliminating 14 bundled ffmpeg CVEs. The contrib-headless variant is a strict superset of the cv2 API (core + contrib modules, no GUI) and can transparently replace `opencv-python`, `opencv-python-headless`, or `opencv-contrib-python`. Wheel is downloaded from the upstream `Unstructured-IO/unstructured` release and hash-verified. Mirrors [unstructured#4336](https://github.com/Unstructured-IO/unstructured/pull/4336).
+
 ## 0.1.3
 
 ### Security

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,6 +75,46 @@ RUN ${PYTHON} -c "from unstructured.nlp.tokenize import _load_spacy_model; _load
     ${PYTHON} -c "from unstructured.partition.model_init import initialize; initialize()" && \
     ${PYTHON} -c "from unstructured_inference.models.tables import UnstructuredTableTransformerModel; model = UnstructuredTableTransformerModel(); model.initialize('microsoft/table-transformer-structure-recognition')"
 
+# Replace PyPI opencv wheels (which bundle vulnerable ffmpeg 5.1.x with 14 CVEs)
+# with a source-built opencv-contrib-python-headless wheel compiled with
+# WITH_FFMPEG=OFF + ENABLE_CONTRIB=1 + ENABLE_HEADLESS=1.
+#
+# The contrib-headless variant is a strict superset of the cv2 API exposed by
+# opencv-python, opencv-python-headless, and opencv-contrib-python, so a
+# single wheel can replace any of them. Because the wheel's metadata name
+# only matches opencv-contrib-python-headless, any other variant has to be
+# uninstalled first - `uv pip install --reinstall-package` would silently
+# no-op for the non-matching names. We uninstall each variant individually
+# with `|| true` to tolerate variants that aren't present (our lockfile
+# currently only resolves opencv-python, but this stays robust if transitive
+# deps change).
+#
+# See: https://github.com/opencv/opencv-python/issues/1212
+#
+# Note: uv.lock resolves opencv packages to 4.13.0.92, but our wheel is pinned
+# to 4.12.0.88 because 4.13.0.92 has no sdist on PyPI — the upstream
+# Unstructured-IO/unstructured GHA workflow (build-opencv-wheels.yml)
+# compiles from source and requires an sdist. Bump this when a newer version
+# publishes an sdist.
+ARG OPENCV_WHEEL_TAG=opencv-4.12.0.88
+ARG OPENCV_WHEEL_VERSION=4.12.0.88
+# SHA-256 hashes of the wheels published in the upstream
+# Unstructured-IO/unstructured release. Update these when bumping
+# OPENCV_WHEEL_VERSION.
+ARG OPENCV_SHA256_aarch64=498fbb787dbfe7d6bc853ddad4ea1154e8fbefbfafd05aafb417f576e27850d5
+ARG OPENCV_SHA256_x86_64=50545ffc1efabf06cd70894b65a7fbca56786f560f452bf67a42c1bbd7a85961
+RUN ARCH=$(uname -m) && \
+    WHEEL="opencv_contrib_python_headless-${OPENCV_WHEEL_VERSION}-cp312-cp312-linux_${ARCH}.whl" && \
+    wget -q -O /tmp/"${WHEEL}" \
+      "https://github.com/Unstructured-IO/unstructured/releases/download/${OPENCV_WHEEL_TAG}/${WHEEL}" && \
+    EXPECTED=$(eval echo "\$OPENCV_SHA256_${ARCH}") && \
+    echo "${EXPECTED}  /tmp/${WHEEL}" | sha256sum -c - && \
+    for pkg in opencv-python opencv-python-headless opencv-contrib-python opencv-contrib-python-headless; do \
+      uv pip uninstall "$pkg" 2>/dev/null || true; \
+    done && \
+    uv pip install --no-deps /tmp/"${WHEEL}" && \
+    rm /tmp/"${WHEEL}"
+
 COPY --chown=${NB_USER}:${NB_USER} CHANGELOG.md CHANGELOG.md
 COPY --chown=${NB_USER}:${NB_USER} logger_config.yaml logger_config.yaml
 COPY --chown=${NB_USER}:${NB_USER} prepline_${PIPELINE_PACKAGE}/ prepline_${PIPELINE_PACKAGE}/

--- a/prepline_general/api/__version__.py
+++ b/prepline_general/api/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.1.3"  # pragma: no cover
+__version__ = "0.1.4"  # pragma: no cover


### PR DESCRIPTION
## Summary
Mirrors [Unstructured-IO/unstructured#4336](https://github.com/Unstructured-IO/unstructured/pull/4336) in this repo so the `quay.io/unstructured-io/unstructured-api` image no longer ships the 14 ffmpeg 5.1.x CVEs bundled in PyPI `opencv-python` wheels.

After `uv sync`, the Dockerfile now:
- Downloads the architecture-specific `opencv-contrib-python-headless` wheel (built with `WITH_FFMPEG=OFF` + `ENABLE_CONTRIB=1` + `ENABLE_HEADLESS=1`) from the upstream `Unstructured-IO/unstructured` GitHub release (`opencv-4.12.0.88`)
- SHA-256-verifies against the hashes published by the upstream `build-opencv-wheels.yml` workflow
- Uninstalls any installed PyPI opencv variants and installs the verified wheel with `--no-deps`

The contrib-headless variant is a strict superset of the `cv2` API exposed by `opencv-python`, `opencv-python-headless`, and `opencv-contrib-python`, so a single wheel transparently replaces whichever variant is present.

## One deviation from upstream
Upstream uninstalls all four opencv variants in a single `uv pip uninstall …` call because their image pulls all four transitively (via `unstructured-paddleocr`). Our `uv.lock` currently only resolves `opencv-python`, so a single combined uninstall would fail on the three that aren't installed. Replaced with a per-package loop using `|| true` — same end state, robust if transitive deps change.

## Version / Changelog
- Bumps service version `0.1.3` → `0.1.4`
- `CHANGELOG.md` entry under `0.1.4` → Security
- No `uv lock` changes needed; the lockfile still resolves `opencv-python 4.13.0.92`, and we overlay the 4.12.0.88 contrib-headless wheel only at image build time (upstream 4.13.0.92 has no sdist on PyPI, which is why the build-from-source workflow is pinned to 4.12.0.88).

## Test plan
- [ ] `make docker-build` succeeds on `amd64` and `arm64`; the opencv replacement step resolves the architecture-specific wheel and the SHA-256 check passes
- [ ] `docker run … python -c "import cv2; print(cv2.__version__)"` prints `4.12.0.88` inside the built image
- [ ] `make docker-test` passes against the rebuilt image
- [ ] Container scan of the rebuilt image no longer flags the 14 ffmpeg CVEs called out by upstream PR #4336

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes a core binary dependency (`opencv`) at image build time via an external wheel download and forced uninstall/reinstall, which could impact image build reliability or runtime CV2 behavior across architectures.
> 
> **Overview**
> Updates the Docker build to **remove vulnerable ffmpeg-bundled PyPI OpenCV wheels** by downloading an arch-specific, SHA-256-verified `opencv-contrib-python-headless` wheel built with `WITH_FFMPEG=OFF`, uninstalling any installed OpenCV variants, and reinstalling the verified wheel.
> 
> Bumps the service version to `0.1.4` and adds a `CHANGELOG.md` security entry documenting the OpenCV/ffmpeg CVE mitigation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e23afcc65a256204d54cd844765007114658098. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->