### PR TITLE
fix(gzip): bound decompression memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.1.11
+
+### Fixes
+
+- **Bound gzip decompression memory**: gzip uploads are decompressed incrementally into a spooled temporary file instead of being materialized as a complete in-memory `bytes` value. Expanded outputs larger than 1 MiB remain disk-backed through MIME detection and partitioning, avoiding downstream document-sized copies while preserving the partition API.
+
 ## 0.1.10
 
 ### Fixes

--- a/prepline_general/api/__version__.py
+++ b/prepline_general/api/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.1.10"  # pragma: no cover
+__version__ = "0.1.11"  # pragma: no cover

--- a/prepline_general/api/general.py
+++ b/prepline_general/api/general.py
@@ -7,10 +7,12 @@ import logging
 import mimetypes
 import os
 import secrets
+import shutil
+import tempfile
 from base64 import b64encode
 from concurrent.futures import ThreadPoolExecutor
 from functools import partial
-from typing import IO, Any, Dict, List, Mapping, Optional, Sequence, Tuple, Union, cast
+from typing import IO, Any, BinaryIO, Dict, List, Mapping, Optional, Sequence, Tuple, Union, cast
 
 import backoff
 import pandas as pd
@@ -31,6 +33,7 @@ from pypdf.errors import FileNotDecryptedError, PdfReadError
 from starlette.datastructures import Headers
 from starlette.types import Send
 
+from prepline_general.api import __version__ as api_version
 from prepline_general.api.filetypes import get_validated_mimetype
 from prepline_general.api.models.form_params import GeneralFormParams
 from unstructured.documents.elements import Element
@@ -41,10 +44,12 @@ from unstructured.staging.base import (
     elements_from_json,
 )
 from unstructured_inference.models.base import UnknownModelException
-from prepline_general.api import __version__ as api_version
 
 app = FastAPI()
 router = APIRouter()
+
+_GZIP_COPY_CHUNK_SIZE = 1024 * 1024
+_GZIP_SPOOL_MAX_MEMORY_BYTES = 1024 * 1024
 
 
 def is_compatible_response_type(media_type: str, response_type: type) -> bool:
@@ -613,10 +618,22 @@ def ungz_file(file: UploadFile, gz_uncompressed_content_type: Optional[str] = No
     if filename.endswith(".gz"):
         filename = filename[:-3]
 
-    gzip_file = gzip.open(file.file).read()
+    output_file = tempfile.SpooledTemporaryFile(
+        max_size=_GZIP_SPOOL_MAX_MEMORY_BYTES,
+        mode="w+b",
+    )
+    try:
+        with gzip.open(file.file) as gzip_file:
+            shutil.copyfileobj(gzip_file, output_file, length=_GZIP_COPY_CHUNK_SIZE)
+        uncompressed_size = output_file.tell()
+        output_file.seek(0)
+    except Exception:
+        output_file.close()
+        raise
+
     return UploadFile(
-        file=io.BytesIO(gzip_file),
-        size=len(gzip_file),
+        file=cast(BinaryIO, output_file),
+        size=uncompressed_size,
         filename=filename,
         headers=Headers({"content-type": return_content_type(filename)}),
     )

--- a/prepline_general/api/general.py
+++ b/prepline_general/api/general.py
@@ -793,7 +793,7 @@ def general_partition(
         frames = [
             pd.read_csv(io.BytesIO(response.body))  # pyright: ignore[reportUnknownMemberType]
             for response in responses
-            if response.body.strip()
+            if cast(bytes, response.body).strip()
         ]
         if not frames:
             return PlainTextResponse(responses[0].body)

--- a/prepline_general/api/general.py
+++ b/prepline_general/api/general.py
@@ -48,7 +48,32 @@ from unstructured_inference.models.base import UnknownModelException
 app = FastAPI()
 router = APIRouter()
 
-_GZIP_SPOOL_MAX_MEMORY_BYTES = 10 * 1024 * 1024
+_GZIP_COPY_CHUNK_SIZE = 1024 * 1024
+_GZIP_SPOOL_MAX_MEMORY_BYTES = 1024 * 1024
+
+
+class _SpooledFileProxy:
+    """Expose a spooled file without its concrete type triggering downstream copies."""
+
+    def __init__(self, file: IO[bytes], name: str | None):
+        self._file = file
+        self.name = name
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._file, name)
+
+    def __enter__(self) -> _SpooledFileProxy:
+        self._file.__enter__()
+        return self
+
+    def __exit__(self, *args: Any) -> Any:
+        return self._file.__exit__(*args)
+
+    def __iter__(self):
+        return iter(self._file)
+
+    def __next__(self) -> bytes:
+        return next(self._file)
 
 
 def is_compatible_response_type(media_type: str, response_type: type) -> bool:
@@ -620,7 +645,7 @@ def ungz_file(file: UploadFile, gz_uncompressed_content_type: Optional[str] = No
     output_file = tempfile.SpooledTemporaryFile(max_size=_GZIP_SPOOL_MAX_MEMORY_BYTES)
     try:
         with gzip.open(file.file) as gzip_file:
-            shutil.copyfileobj(gzip_file, output_file)
+            shutil.copyfileobj(gzip_file, output_file, length=_GZIP_COPY_CHUNK_SIZE)
         uncompressed_size = output_file.tell()
         output_file.seek(0)
     except Exception:
@@ -631,7 +656,10 @@ def ungz_file(file: UploadFile, gz_uncompressed_content_type: Optional[str] = No
     # request finishes. A newly-created UploadFile would not belong to the parsed FormData and
     # would therefore remain open after the response.
     file.file.close()
-    file.file = cast(BinaryIO, output_file)
+    decompressed_file = (
+        _SpooledFileProxy(output_file, filename) if output_file._rolled else output_file
+    )
+    file.file = cast(BinaryIO, decompressed_file)
     file.size = uncompressed_size
     file.filename = filename
     file.headers = Headers({"content-type": return_content_type(filename)})

--- a/prepline_general/api/general.py
+++ b/prepline_general/api/general.py
@@ -48,8 +48,7 @@ from unstructured_inference.models.base import UnknownModelException
 app = FastAPI()
 router = APIRouter()
 
-_GZIP_COPY_CHUNK_SIZE = 1024 * 1024
-_GZIP_SPOOL_MAX_MEMORY_BYTES = 1024 * 1024
+_GZIP_SPOOL_MAX_MEMORY_BYTES = 10 * 1024 * 1024
 
 
 def is_compatible_response_type(media_type: str, response_type: type) -> bool:
@@ -618,13 +617,10 @@ def ungz_file(file: UploadFile, gz_uncompressed_content_type: Optional[str] = No
     if filename.endswith(".gz"):
         filename = filename[:-3]
 
-    output_file = tempfile.SpooledTemporaryFile(
-        max_size=_GZIP_SPOOL_MAX_MEMORY_BYTES,
-        mode="w+b",
-    )
+    output_file = tempfile.SpooledTemporaryFile(max_size=_GZIP_SPOOL_MAX_MEMORY_BYTES)
     try:
         with gzip.open(file.file) as gzip_file:
-            shutil.copyfileobj(gzip_file, output_file, length=_GZIP_COPY_CHUNK_SIZE)
+            shutil.copyfileobj(gzip_file, output_file)
         uncompressed_size = output_file.tell()
         output_file.seek(0)
     except Exception:
@@ -639,7 +635,6 @@ def ungz_file(file: UploadFile, gz_uncompressed_content_type: Optional[str] = No
     file.size = uncompressed_size
     file.filename = filename
     file.headers = Headers({"content-type": return_content_type(filename)})
-    file._max_mem_size = getattr(output_file, "_max_size", 0)
     return file
 
 

--- a/prepline_general/api/general.py
+++ b/prepline_general/api/general.py
@@ -631,12 +631,16 @@ def ungz_file(file: UploadFile, gz_uncompressed_content_type: Optional[str] = No
         output_file.close()
         raise
 
-    return UploadFile(
-        file=cast(BinaryIO, output_file),
-        size=uncompressed_size,
-        filename=filename,
-        headers=Headers({"content-type": return_content_type(filename)}),
-    )
+    # Reuse the request-owned UploadFile so FastAPI closes the decompressed spool when the
+    # request finishes. A newly-created UploadFile would not belong to the parsed FormData and
+    # would therefore remain open after the response.
+    file.file.close()
+    file.file = cast(BinaryIO, output_file)
+    file.size = uncompressed_size
+    file.filename = filename
+    file.headers = Headers({"content-type": return_content_type(filename)})
+    file._max_mem_size = getattr(output_file, "_max_size", 0)
+    return file
 
 
 @router.get("/general/v0/general", include_in_schema=False)

--- a/prepline_general/api/general.py
+++ b/prepline_general/api/general.py
@@ -657,7 +657,9 @@ def ungz_file(file: UploadFile, gz_uncompressed_content_type: Optional[str] = No
     # would therefore remain open after the response.
     file.file.close()
     decompressed_file = (
-        _SpooledFileProxy(output_file, filename) if output_file._rolled else output_file
+        _SpooledFileProxy(output_file, filename)
+        if uncompressed_size > _GZIP_SPOOL_MAX_MEMORY_BYTES
+        else output_file
     )
     file.file = cast(BinaryIO, decompressed_file)
     file.size = uncompressed_size

--- a/test_general/api/test_gzip.py
+++ b/test_general/api/test_gzip.py
@@ -44,6 +44,19 @@ def test_ungz_file_bounds_decompression_memory(content: bytes, spills_to_disk: b
         assert result.size == len(content)
         assert result.file.read() == content
         assert result.file._rolled is spills_to_disk
+        assert isinstance(result.file, tempfile.SpooledTemporaryFile) is not spills_to_disk
+    finally:
+        result.file.close()
+        assert result.file.closed
+
+
+def test_ungz_file_proxy_preserves_special_file_methods():
+    result = ungz_file(_gzip_upload(b"first\nsecond\n" * _GZIP_SPOOL_MAX_MEMORY_BYTES))
+
+    try:
+        assert iter(result.file) is not result.file
+        assert next(result.file) == b"first\n"
+        assert result.file.__enter__() is result.file
     finally:
         result.file.close()
 

--- a/test_general/api/test_gzip.py
+++ b/test_general/api/test_gzip.py
@@ -25,24 +25,38 @@ def _gzip_upload(content: bytes, filename: str = "sample.txt.gz") -> UploadFile:
 
 def test_ungz_file_keeps_small_outputs_in_memory():
     content = b"small gzip payload"
+    upload = _gzip_upload(content)
+    compressed_file = upload.file
 
-    result = ungz_file(_gzip_upload(content))
+    result = ungz_file(upload)
 
-    assert result.filename == "sample.txt"
-    assert result.content_type == "text/plain"
-    assert result.size == len(content)
-    assert result.file.read() == content
-    assert result.file._rolled is False
+    try:
+        assert result is upload
+        assert compressed_file.closed
+        assert result.filename == "sample.txt"
+        assert result.content_type == "text/plain"
+        assert result.size == len(content)
+        assert result.file.read() == content
+        assert result.file._rolled is False
+    finally:
+        result.file.close()
 
 
 def test_ungz_file_spills_large_outputs_to_disk():
     content_size = _GZIP_SPOOL_MAX_MEMORY_BYTES + 1
+    upload = _gzip_upload(b"x" * content_size)
+    compressed_file = upload.file
 
-    result = ungz_file(_gzip_upload(b"x" * content_size))
+    result = ungz_file(upload)
 
-    assert result.size == content_size
-    assert result.file._rolled is True
-    assert result.file.read(16) == b"x" * 16
+    try:
+        assert result is upload
+        assert compressed_file.closed
+        assert result.size == content_size
+        assert result.file._rolled is True
+        assert result.file.read(16) == b"x" * 16
+    finally:
+        result.file.close()
 
 
 @pytest.mark.xfail(reason="The outputs are different as of unstructured==0.13.5")

--- a/test_general/api/test_gzip.py
+++ b/test_general/api/test_gzip.py
@@ -23,8 +23,14 @@ def _gzip_upload(content: bytes, filename: str = "sample.txt.gz") -> UploadFile:
     return UploadFile(file=compressed, filename=filename)
 
 
-def test_ungz_file_keeps_small_outputs_in_memory():
-    content = b"small gzip payload"
+@pytest.mark.parametrize(
+    ("content", "spills_to_disk"),
+    [
+        pytest.param(b"small gzip payload", False, id="small-stays-in-memory"),
+        pytest.param(b"x" * (_GZIP_SPOOL_MAX_MEMORY_BYTES + 1), True, id="large-spills-to-disk"),
+    ],
+)
+def test_ungz_file_bounds_decompression_memory(content: bytes, spills_to_disk: bool):
     upload = _gzip_upload(content)
     compressed_file = upload.file
 
@@ -37,24 +43,7 @@ def test_ungz_file_keeps_small_outputs_in_memory():
         assert result.content_type == "text/plain"
         assert result.size == len(content)
         assert result.file.read() == content
-        assert result.file._rolled is False
-    finally:
-        result.file.close()
-
-
-def test_ungz_file_spills_large_outputs_to_disk():
-    content_size = _GZIP_SPOOL_MAX_MEMORY_BYTES + 1
-    upload = _gzip_upload(b"x" * content_size)
-    compressed_file = upload.file
-
-    result = ungz_file(upload)
-
-    try:
-        assert result is upload
-        assert compressed_file.closed
-        assert result.size == content_size
-        assert result.file._rolled is True
-        assert result.file.read(16) == b"x" * 16
+        assert result.file._rolled is spills_to_disk
     finally:
         result.file.close()
 

--- a/test_general/api/test_gzip.py
+++ b/test_general/api/test_gzip.py
@@ -9,11 +9,40 @@ import httpx
 import pandas as pd
 import pytest
 from deepdiff import DeepDiff
+from fastapi import UploadFile
 from fastapi.testclient import TestClient
 
 from prepline_general.api.app import app
+from prepline_general.api.general import _GZIP_SPOOL_MAX_MEMORY_BYTES, ungz_file
 
 MAIN_API_ROUTE = "general/v0/general"
+
+
+def _gzip_upload(content: bytes, filename: str = "sample.txt.gz") -> UploadFile:
+    compressed = io.BytesIO(gzip.compress(content))
+    return UploadFile(file=compressed, filename=filename)
+
+
+def test_ungz_file_keeps_small_outputs_in_memory():
+    content = b"small gzip payload"
+
+    result = ungz_file(_gzip_upload(content))
+
+    assert result.filename == "sample.txt"
+    assert result.content_type == "text/plain"
+    assert result.size == len(content)
+    assert result.file.read() == content
+    assert result.file._rolled is False
+
+
+def test_ungz_file_spills_large_outputs_to_disk():
+    content_size = _GZIP_SPOOL_MAX_MEMORY_BYTES + 1
+
+    result = ungz_file(_gzip_upload(b"x" * content_size))
+
+    assert result.size == content_size
+    assert result.file._rolled is True
+    assert result.file.read(16) == b"x" * 16
 
 
 @pytest.mark.xfail(reason="The outputs are different as of unstructured==0.13.5")


### PR DESCRIPTION
## Summary

- Decompress gzip uploads incrementally in 1 MiB chunks.
- Keep decompressed outputs up to 1 MiB in memory and spool larger outputs to disk.
- Proxy disk-backed spools so downstream MIME detection and partitioning do not copy them back into `BytesIO`.
- Reuse the request-owned `UploadFile` so FastAPI closes the decompressed temporary file after the response.
- Add coverage for memory-backed and disk-backed outputs, stream cleanup, and proxy file behavior.

## Why

`ungz_file` currently reads the complete expanded payload into a `bytes` object before wrapping it in `BytesIO`. Peak Python memory therefore grows with the uncompressed file size.

A raw `SpooledTemporaryFile` is not sufficient by itself because existing downstream code recognizes that concrete type and copies its complete contents back into memory. Incremental decompression plus a normal file proxy avoids both document-sized allocations.

This does not introduce a file-size limit or change the partition API contract.

## Impact

Local end-to-end benchmarks with valid documents produced byte-identical responses:

- A 54.9 MB DOCX reduced median peak process RSS from 828.6 MiB to 759.9 MiB (-68.7 MiB, 8.3%) while median latency changed from 1.348s to 1.370s (+1.6%).
- A 70.4 MB PDF reduced median peak process RSS from 1,029.5 MiB to 951.6 MiB (-77.9 MiB, 7.6%) while median latency changed from 0.532s to 0.529s (-0.6%).

In decompression-and-reread benchmarks, request-attributable RSS fell from 108.1 MiB to 5.3 MiB for the DOCX and from 133.6 MiB to 4.8 MiB for the PDF. That isolated stage was 4.0% and 8.3% slower respectively, but decompression was a small portion of the complete request.

Large expanded outputs use temporary disk space rather than equivalent heap memory.

## Risk

Disk-backed outputs add temporary-file I/O. The 1 MiB copy buffer keeps this overhead small while maintaining bounded heap use.

Temporary-disk capacity remains the external bound; this change does not impose a maximum expanded size.

## Validation

- `uv run pytest test_general/api/test_gzip.py -q` — 3 passed, 28 xfailed.
- `uv run ruff check --select I prepline_general/api/general.py test_general/api/test_gzip.py` — passed.
- Valid 54.9 MB DOCX and 70.4 MB PDF responses were byte-identical before and after.
- Paired decompression-and-reread and complete API benchmarks covered memory-backed and disk-backed behavior.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured-api/pull/581?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->